### PR TITLE
fix: use production build for docs to fix social card URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ environment
     └── data.csv
 ```
 
-To add actions to an environment, simply define commands in any markdown header. As agents browse files, they will discover these tools and learn how to use them with the `--help` flag.
+To add tool to an environment, simply define commands in any markdown header. As agents browse files, they will discover these tools and learn how to use them with the `--help` flag.
 
 ```markdown
 ---

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     libffi-dev \
     shared-mime-info \
     git \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv
@@ -40,5 +41,8 @@ COPY index.md ./docs/
 # Expose port 8080
 EXPOSE 8080
 
-# Run mkdocs serve
-CMD ["mkdocs", "serve", "--dev-addr", "0.0.0.0:8080"]
+# Build the site
+RUN mkdocs build
+
+# Serve static files
+CMD ["python", "-m", "http.server", "8080", "--directory", "site"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ environment
 ```
 
 
-To add actions to an environment, simply define commands in any markdown header. As agents browse files, they will discover these tools and learn how to use them with the `--help` flag.
+To add tools to an environment, simply define commands in any markdown header. As agents browse files, they will discover these tools and learn how to use them with the `--help` flag.
 
 ```markdown title="index.md"
 ---


### PR DESCRIPTION
## Summary
- Fix social card previews by switching from development server to production build
- Social cards now generate correct URLs using `site_url: https://docs.toolfront.ai` instead of `http://0.0.0.0:8080`

## Changes
- Updated Dockerfile to use `mkdocs build` + static file serving instead of `mkdocs serve`
- Added `pkg-config` dependency for Cairo image generation
- This ensures social plugin respects the configured `site_url` during build

## Testing
- Verified social cards now show correct previews with proper image URLs
- Production deployment generates images with `https://docs.toolfront.ai` URLs