### PR TITLE
Fix failing deploy unit test

### DIFF
--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -68,7 +68,7 @@ class TestDeployCommand:
                 id="env-123",
                 auth_token="token-abc",
                 url="https://cf.example.com",
-                fly_url=None,
+                fly_url="https://fly.example.com",
             )
             mock_client.return_value = mock_instance
 


### PR DESCRIPTION
## Summary
- Fixed the failing unit test `test_displays_deployment_results` in `tests/unit/test_deploy.py`
- The test was failing because the deploy command only displays the URL when `fly_url` is present
- Set `fly_url` in the mock `DeployResult` to match the test expectations
- Test now passes while maintaining existing behavior

## Changes
- Updated mock data in `test_displays_deployment_results` to include `fly_url="https://fly.example.com"`
- This ensures the URL is displayed in the output as expected by the test assertions