### PR TITLE
Add dedicated /action endpoint

### DIFF
--- a/src/toolfront/application.py
+++ b/src/toolfront/application.py
@@ -74,18 +74,17 @@ class Application(BaseModel):
         Commands can parse directories, query databases, call APIs, etc.
 
         Instructions:
-        1. url MUST ALWAYS be a complete HTTP/HTTPS URL to a file (e.g., 'https://example.com/docs/index.md')
-        2. The URL must point to the specific .md file where the command is defined in the frontmatter
-        3. To discover available commands and their URLs, use previously discovered/read tools and documentation
-        4. IMPORTANT: You can ONLY execute commands explicitly listed in the page's frontmatter. Never call a command you haven't found in the .md file
-        5. Commands must exactly match those in the frontmatter (they may include placeholders like '{endpoint}' or '{id}')
-        6. If you don't know what a command does, run it with --help first (e.g., ['command', '--help'])
-        7. Replace command placeholders with actual values from the args dict when executing
+        1. url MUST ALWAYS be a complete HTTP/HTTPS URL to the base application (e.g., 'https://example.com')
+        2. To discover available commands and their URLs, use previously discovered/read tools and documentation
+        3. IMPORTANT: You can ONLY execute commands explicitly listed in the page's frontmatter. Never call a command you haven't found in the .md file
+        4. Commands must exactly match those in the frontmatter (they may include placeholders like '{endpoint}' or '{id}')
+        5. If you don't know what a command does, run it with --help first (e.g., ['command', '--help'])
+        6. Replace command placeholders with actual values from the args dict when executing
 
         Parameters
         ----------
         url : str
-            Complete HTTP/HTTPS URL to the .md file where the command is defined (e.g., 'https://example.com/docs/index.md')
+            Complete HTTP/HTTPS URL to the base application (e.g., 'https://example.com')
             MUST always be a full URL, never a file:// path
         command : list[str]
             Command and its arguments (e.g., ['curl', '-X', 'GET', 'https://api.com/{endpoint}']). REQUIRED.
@@ -115,8 +114,9 @@ class Application(BaseModel):
                 if self.env is not None:
                     payload["env"] = self.env
 
+                action_url = f"{str(url).rstrip('/')}/action"
                 response = await client.post(
-                    url,
+                    action_url,
                     json=payload,
                     headers=self.param or {},
                     timeout=DEFAULT_TIMEOUT_SECONDS,

--- a/src/toolfront/lib/gateway.py
+++ b/src/toolfront/lib/gateway.py
@@ -83,7 +83,7 @@ class GatewayClient:
         for attempt in range(1, max_attempts + 1):
             try:
                 response = httpx.get(
-                    f"{url}/README.md",
+                    url,
                     headers={"Authorization": f"Bearer {auth_token}"},
                     timeout=10.0,
                     follow_redirects=True,


### PR DESCRIPTION
## Changes

- Update serve.py to add POST /action endpoint (instead of POST /{path})
- Add optional path parameter to ActionRequest for specifying which file to use
- Update Application.action() to POST to /action endpoint
- Update GatewayClient.verify_environment() to use base URL (no longer appends /README.md)
- Update help text to reflect new endpoint structure

## Behavior

**Before:**
- POST http://localhost:8000/README.md with {command, args}
- POST http://localhost:8000/path/to/file.md with {command, args}

**After:**
- POST http://localhost:8000/action with {command, args, path: null} (uses root README.md)
- POST http://localhost:8000/action with {command, args, path: "operations"} (uses operations/README.md)

This mirrors the gateway changes in PR #119 and makes URLs cleaner.