### PR TITLE
fix: remove mkdocstrings config to fix docs deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ test = [
     "pytest-httpx>=0.30.0",
 ]
 dev = [
-    "mkdocstrings-python>=2.0.1",
     "pre-commit>=3.0.0",
     "ruff>=0.1.0",
     "zensical>=0.0.11",

--- a/zensical.toml
+++ b/zensical.toml
@@ -62,15 +62,6 @@ features = [
 [project.extra]
 generator = false
 
-[project.plugins.mkdocstrings.handlers.python]
-inventories = ["https://docs.python.org/3/objects.inv"]
-paths = ["src"]
-
-[project.plugins.mkdocstrings.handlers.python.options]
-docstring_style = "numpy"
-inherited_members = true
-show_source = false
-
 [[project.extra.social]]
   icon = "fontawesome/brands/github"
   link = "https://github.com/statespace-tech/toolfront/"


### PR DESCRIPTION
## Summary
- Remove mkdocstrings plugin configuration from `zensical.toml`
- Remove `mkdocstrings-python` from dev dependencies in `pyproject.toml`

The error: `ModuleNotFoundError: No module named 'mkdocstrings'`