### PR TITLE
feat: revive token CLI commands

### DIFF
--- a/binaries/statespace-cli/src/args.rs
+++ b/binaries/statespace-cli/src/args.rs
@@ -46,6 +46,12 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: SshCommands,
     },
+
+    /// Token management commands
+    Tokens {
+        #[command(subcommand)]
+        command: TokensCommands,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -237,4 +243,93 @@ pub(crate) enum SshCommands {
         #[command(subcommand)]
         command: SshKeyCommands,
     },
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum TokensCommands {
+    /// Create a new personal access token
+    Create(TokenCreateArgs),
+
+    /// List personal access tokens
+    List(TokenListArgs),
+
+    /// Show details for a token
+    Get(TokenGetArgs),
+
+    /// Rotate a token (revoke old, issue new)
+    Rotate(TokenRotateArgs),
+
+    /// Revoke a token
+    Revoke(TokenRevokeArgs),
+}
+
+#[derive(Debug, Parser)]
+pub(crate) struct TokenCreateArgs {
+    /// Token name
+    pub name: String,
+
+    /// Token scope (read or admin)
+    #[arg(long, short, default_value = "read")]
+    pub scope: String,
+
+    /// Restrict token to specific environment IDs
+    #[arg(long = "app-id")]
+    pub app_ids: Vec<String>,
+
+    /// Expiration (ISO 8601 datetime, e.g. 2026-12-31T00:00:00Z)
+    #[arg(long)]
+    pub expires: Option<String>,
+}
+
+#[derive(Debug, Parser)]
+pub(crate) struct TokenListArgs {
+    /// Show all tokens including revoked
+    #[arg(long, short)]
+    pub all: bool,
+
+    /// Maximum number of tokens to return
+    #[arg(long, short, default_value = "100")]
+    pub limit: u32,
+}
+
+#[derive(Debug, Parser)]
+pub(crate) struct TokenGetArgs {
+    /// Token ID
+    pub token_id: String,
+}
+
+#[derive(Debug, Parser)]
+pub(crate) struct TokenRotateArgs {
+    /// Token ID to rotate
+    pub token_id: String,
+
+    /// New name
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// New scope (read or admin)
+    #[arg(long)]
+    pub scope: Option<String>,
+
+    /// Restrict to specific environment IDs
+    #[arg(long = "app-id")]
+    pub app_ids: Vec<String>,
+
+    /// New expiration (ISO 8601 datetime)
+    #[arg(long)]
+    pub expires: Option<String>,
+}
+
+#[derive(Debug, Parser)]
+pub(crate) struct TokenRevokeArgs {
+    /// Token ID to revoke
+    pub token_id: String,
+
+    /// Revocation reason
+    #[arg(long, short)]
+    pub reason: Option<String>,
+
+    /// Skip confirmation prompt
+    #[arg(long, short)]
+    pub yes: bool,
 }

--- a/binaries/statespace-cli/src/commands/mod.rs
+++ b/binaries/statespace-cli/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub(crate) mod ssh;
 pub(crate) mod ssh_config;
 pub(crate) mod ssh_key;
 pub(crate) mod sync;
+pub(crate) mod tokens;

--- a/binaries/statespace-cli/src/commands/tokens.rs
+++ b/binaries/statespace-cli/src/commands/tokens.rs
@@ -1,0 +1,207 @@
+use crate::args::{
+    TokenCreateArgs, TokenGetArgs, TokenListArgs, TokenRevokeArgs, TokenRotateArgs, TokensCommands,
+};
+use crate::error::Result;
+use crate::gateway::GatewayClient;
+use chrono::{DateTime, Utc};
+use std::io::{self, Write};
+
+pub(crate) async fn run(cmd: TokensCommands, gateway: GatewayClient) -> Result<()> {
+    match cmd {
+        TokensCommands::Create(args) => run_create(args, gateway).await,
+        TokensCommands::List(args) => run_list(args, gateway).await,
+        TokensCommands::Get(args) => run_get(args, gateway).await,
+        TokensCommands::Rotate(args) => run_rotate(args, gateway).await,
+        TokensCommands::Revoke(args) => run_revoke(args, gateway).await,
+    }
+}
+
+async fn run_create(args: TokenCreateArgs, gateway: GatewayClient) -> Result<()> {
+    eprintln!("Creating token '{}'...", args.name);
+
+    let app_ids = if args.app_ids.is_empty() {
+        None
+    } else {
+        Some(args.app_ids.as_slice())
+    };
+
+    let result = gateway
+        .create_token(&args.name, &args.scope, app_ids, args.expires.as_deref())
+        .await?;
+
+    println!();
+    println!("{}", "=".repeat(80));
+    print_kv("Token ID:", &result.id);
+    print_kv("Name:", &result.name);
+    print_kv("Scope:", &result.scope);
+    print_kv("Created:", &result.created_at);
+    if let Some(expires) = &result.expires_at {
+        print_kv("Expires:", expires);
+    }
+    println!();
+    println!("{}", "─".repeat(80));
+    println!("  Token (save this — shown only once):");
+    println!("  {}", result.token);
+    println!("{}", "=".repeat(80));
+    eprintln!("\n✓ Token created");
+
+    Ok(())
+}
+
+async fn run_list(args: TokenListArgs, gateway: GatewayClient) -> Result<()> {
+    let tokens = gateway.list_tokens(!args.all, args.limit, 0).await?;
+
+    if tokens.is_empty() {
+        println!("No tokens found.");
+        return Ok(());
+    }
+
+    eprintln!("{} token(s)\n", tokens.len());
+
+    for token in tokens {
+        let status = if token.is_active { "✓" } else { "✗" };
+        let scope = token.scope.replace("environments:", "");
+        let time_ago = format_relative_time(&token.created_at);
+        let short_id = if token.id.len() > 12 {
+            &token.id[token.id.len() - 12..]
+        } else {
+            &token.id
+        };
+
+        println!("{status} {}", token.name);
+        println!("  {scope} • {time_ago} • {short_id}");
+
+        if token.usage_count > 0 {
+            let last_used = token
+                .last_used_at
+                .as_deref()
+                .map_or_else(|| "never".to_string(), format_relative_time);
+            println!("  Used {} time(s), last: {last_used}", token.usage_count);
+        }
+        println!();
+    }
+
+    Ok(())
+}
+
+async fn run_get(args: TokenGetArgs, gateway: GatewayClient) -> Result<()> {
+    let token = gateway.get_token(&args.token_id).await?;
+
+    let status = if token.is_active { "active" } else { "revoked" };
+
+    println!();
+    println!("{}", "=".repeat(80));
+    print_kv("ID:", &token.id);
+    print_kv("Name:", &token.name);
+    print_kv("Scope:", &token.scope);
+    print_kv("Status:", status);
+    print_kv("Created:", &token.created_at);
+    if let Some(expires) = &token.expires_at {
+        print_kv("Expires:", expires);
+    }
+    if let Some(last_used) = &token.last_used_at {
+        print_kv("Last used:", last_used);
+    }
+    print_kv("Usage count:", &token.usage_count.to_string());
+
+    if let Some(envs) = &token.allowed_environments {
+        let env_str = if envs.is_empty() {
+            "All".to_string()
+        } else {
+            envs.join(", ")
+        };
+        print_kv("Allowed apps:", &env_str);
+    }
+
+    if let Some(revoked_at) = &token.revoked_at {
+        print_kv("Revoked:", revoked_at);
+        if let Some(by) = &token.revoked_by {
+            print_kv("Revoked by:", by);
+        }
+        if let Some(reason) = &token.revocation_reason {
+            print_kv("Reason:", reason);
+        }
+    }
+    println!("{}", "=".repeat(80));
+
+    Ok(())
+}
+
+async fn run_rotate(args: TokenRotateArgs, gateway: GatewayClient) -> Result<()> {
+    eprintln!("Rotating token {}...", args.token_id);
+
+    let app_ids = if args.app_ids.is_empty() {
+        None
+    } else {
+        Some(args.app_ids.as_slice())
+    };
+
+    let result = gateway
+        .rotate_token(
+            &args.token_id,
+            args.name.as_deref(),
+            args.scope.as_deref(),
+            app_ids,
+            args.expires.as_deref(),
+        )
+        .await?;
+
+    println!();
+    println!("{}", "=".repeat(80));
+    print_kv("Token ID:", &result.id);
+    print_kv("Name:", &result.name);
+    print_kv("Scope:", &result.scope);
+    println!();
+    println!("{}", "─".repeat(80));
+    println!("  New Token (save this — shown only once):");
+    println!("  {}", result.token);
+    println!("{}", "=".repeat(80));
+    eprintln!("\n✓ Token rotated (old token revoked)");
+
+    Ok(())
+}
+
+async fn run_revoke(args: TokenRevokeArgs, gateway: GatewayClient) -> Result<()> {
+    if !args.yes {
+        eprint!("Revoke token {}? [y/N] ", args.token_id);
+        io::stderr().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+
+        if !input.trim().eq_ignore_ascii_case("y") {
+            eprintln!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    gateway
+        .revoke_token(&args.token_id, args.reason.as_deref())
+        .await?;
+    eprintln!("✓ Token revoked");
+
+    Ok(())
+}
+
+fn print_kv(key: &str, value: &str) {
+    println!("  {key:<16} {value}");
+}
+
+fn format_relative_time(iso: &str) -> String {
+    let Ok(dt) = DateTime::parse_from_rfc3339(iso) else {
+        return iso.to_string();
+    };
+
+    let now = Utc::now();
+    let delta = now.signed_duration_since(dt.with_timezone(&Utc));
+
+    if delta.num_days() > 0 {
+        format!("{}d ago", delta.num_days())
+    } else if delta.num_hours() > 0 {
+        format!("{}h ago", delta.num_hours())
+    } else if delta.num_minutes() > 0 {
+        format!("{}m ago", delta.num_minutes())
+    } else {
+        "just now".to_string()
+    }
+}

--- a/binaries/statespace-cli/src/gateway/client.rs
+++ b/binaries/statespace-cli/src/gateway/client.rs
@@ -207,7 +207,7 @@ impl GatewayClient {
         Ok(false)
     }
 
-    #[allow(dead_code, clippy::items_after_statements)]
+    #[allow(clippy::items_after_statements)]
     pub(crate) async fn create_token(
         &self,
         name: &str,
@@ -244,7 +244,6 @@ impl GatewayClient {
         parse_api_response(resp).await
     }
 
-    #[allow(dead_code)]
     pub(crate) async fn list_tokens(
         &self,
         only_active: bool,
@@ -268,7 +267,6 @@ impl GatewayClient {
         parse_api_list_response(resp).await
     }
 
-    #[allow(dead_code)]
     pub(crate) async fn get_token(&self, token_id: &str) -> Result<Token> {
         let url = format!("{}/api/v1/tokens/{}", self.base_url, token_id);
         let resp = self.with_headers(self.http.get(&url)).send().await?;
@@ -276,7 +274,6 @@ impl GatewayClient {
         parse_api_response(resp).await
     }
 
-    #[allow(dead_code)]
     pub(crate) async fn rotate_token(
         &self,
         token_id: &str,
@@ -313,7 +310,6 @@ impl GatewayClient {
         parse_api_response(resp).await
     }
 
-    #[allow(dead_code)]
     pub(crate) async fn revoke_token(&self, token_id: &str, reason: Option<&str>) -> Result<()> {
         #[derive(Serialize)]
         struct Payload<'a> {

--- a/binaries/statespace-cli/src/main.rs
+++ b/binaries/statespace-cli/src/main.rs
@@ -68,6 +68,12 @@ async fn run() -> Result<()> {
             }
         }
 
+        Commands::Tokens { command } => {
+            let creds = resolve_credentials(cli.api_key.as_deref(), cli.org_id.as_deref())?;
+            let gateway = GatewayClient::new(creds)?;
+            commands::tokens::run(command, gateway).await
+        }
+
         Commands::Ssh { command } => match command {
             args::SshCommands::Setup { yes } => commands::ssh_config::run_setup(yes).await,
             args::SshCommands::Uninstall { yes } => commands::ssh_config::run_uninstall(yes),


### PR DESCRIPTION
Restores token CRUD commands (`create`, `list`, `get`, `rotate`, `revoke`) accidentally deleted in 0930313 when they were misclassified as dead code.

The gateway client methods were already intact. This adds back:
- Arg types in `args.rs` (`TokensCommands`, `TokenCreateArgs`, etc.)
- Command handlers in `commands/tokens.rs`
- Wiring in `mod.rs` and `main.rs`
- Removes `#[allow(dead_code)]` from the now-used client methods

All five commands tested against `api.staging.statespace.com`.