### PR TITLE
fix: use cargo set-version for releases

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,13 +50,7 @@ release version:
     echo ""
     read -p "Continue? [y/N] " c && [[ "$c" =~ ^[Yy]$ ]] || exit 0
 
-    if [[ "$OSTYPE" == darwin* ]]; then
-        sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
-    else
-        sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
-    fi
-
-    cargo check --workspace --quiet
+    cargo set-version --workspace "${VERSION}"
 
     git add Cargo.toml Cargo.lock
     git commit -m "chore: release v${VERSION}"


### PR DESCRIPTION
Replaces brittle sed-based version bumping with `cargo set-version` from cargo-edit.

Requires `cargo install cargo-edit` locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the release workflow by consolidating platform-specific version update steps into a single, cross-platform process.
  * Removed an unnecessary validation step from the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->