### PR TITLE
cli: add top-level sync and deploy commands again

### DIFF
--- a/binaries/statespace-cli/src/args.rs
+++ b/binaries/statespace-cli/src/args.rs
@@ -38,6 +38,12 @@ pub(crate) enum Commands {
         command: AppCommands,
     },
 
+    /// Deploy an app (shortcut for `app create`)
+    Deploy(AppCreateArgs),
+
+    /// Sync files to an app (shortcut for `app sync`)
+    Sync(AppSyncArgs),
+
     /// Serve a local app (no account required)
     Serve(ServeArgs),
 

--- a/binaries/statespace-cli/src/main.rs
+++ b/binaries/statespace-cli/src/main.rs
@@ -27,6 +27,18 @@ async fn run() -> Result<()> {
     match cli.command {
         Commands::Auth { command } => commands::auth::run(command).await,
 
+        Commands::Deploy(args) => {
+            let creds = resolve_credentials(cli.api_key.as_deref(), cli.org_id.as_deref())?;
+            let gateway = GatewayClient::new(creds)?;
+            commands::app::run_create(args, gateway).await
+        }
+
+        Commands::Sync(args) => {
+            let creds = resolve_credentials(cli.api_key.as_deref(), cli.org_id.as_deref())?;
+            let gateway = GatewayClient::new(creds)?;
+            commands::sync::run_sync(args, gateway).await
+        }
+
         Commands::Serve(args) => commands::serve::run_serve(args).await,
 
         Commands::Org { command } => {


### PR DESCRIPTION
Re-adds `statespace deploy` and `statespace sync` as top-level shortcuts for `app create` and `app sync`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `deploy` top-level CLI command as a shortcut for `app create`.
  * Added `sync` top-level CLI command as a shortcut for `app sync`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->