### PR TITLE
Omit default visibility from CLI, let server decide

### DIFF
--- a/binaries/statespace-cli/src/args.rs
+++ b/binaries/statespace-cli/src/args.rs
@@ -182,9 +182,9 @@ pub(crate) struct AppCreateArgs {
     #[arg(long, short)]
     pub name: Option<String>,
 
-    /// Environment visibility
-    #[arg(long, default_value = "public")]
-    pub visibility: VisibilityArg,
+    /// Environment visibility (default: private for paid tiers, public for free)
+    #[arg(long)]
+    pub visibility: Option<VisibilityArg>,
 
     /// Wait for the environment to become ready
     #[arg(long)]

--- a/binaries/statespace-cli/src/gateway/client.rs
+++ b/binaries/statespace-cli/src/gateway/client.rs
@@ -110,19 +110,20 @@ impl GatewayClient {
         &self,
         name: &str,
         files: Vec<EnvironmentFile>,
-        visibility: crate::args::VisibilityArg,
+        visibility: Option<crate::args::VisibilityArg>,
     ) -> Result<DeployResult> {
         #[derive(Serialize)]
         struct Payload<'a> {
             name: &'a str,
             files: Vec<EnvironmentFile>,
-            visibility: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            visibility: Option<&'a str>,
         }
 
-        let visibility_str = match visibility {
+        let visibility_str = visibility.map(|v| match v {
             crate::args::VisibilityArg::Public => "public",
             crate::args::VisibilityArg::Private => "private",
-        };
+        });
 
         let url = format!("{}/api/v1/environments", self.base_url);
         let resp = self


### PR DESCRIPTION
Companion to https://github.com/statespace-tech/gateway/pull/303

The CLI no longer hardcodes `--visibility public`. When omitted, the server resolves the default based on org tier (Private for paid, Public for free). The `--visibility` flag still works for explicit overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visibility settings for apps and environments are now optional. The system automatically defaults to private for paid tiers and public for free accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->