### PR TITLE
Add --api-url flag and STATESPACE_GATEWAY_URL env var

### DIFF
--- a/binaries/statespace-cli/src/args.rs
+++ b/binaries/statespace-cli/src/args.rs
@@ -14,6 +14,9 @@ pub(crate) struct Cli {
     #[arg(long, global = true)]
     pub org_id: Option<String>,
 
+    #[arg(long, global = true, env = "STATESPACE_GATEWAY_URL", hide = true)]
+    pub api_url: Option<String>,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/binaries/statespace-cli/src/commands/auth.rs
+++ b/binaries/statespace-cli/src/commands/auth.rs
@@ -9,17 +9,17 @@ use crate::gateway::{AuthClient, DeviceTokenResponse, GatewayClient};
 use std::io::{self, Write};
 use std::time::Duration;
 
-pub(crate) async fn run(cmd: AuthCommands) -> Result<()> {
+pub(crate) async fn run(cmd: AuthCommands, cli_api_url: Option<&str>) -> Result<()> {
     match cmd {
-        AuthCommands::Login => run_login().await,
+        AuthCommands::Login => run_login(cli_api_url).await,
         AuthCommands::Logout => run_logout(),
         AuthCommands::Status => run_status(),
         AuthCommands::Token { format } => run_token(format),
     }
 }
 
-async fn run_login() -> Result<()> {
-    let api_url = resolve_api_url();
+async fn run_login(cli_api_url: Option<&str>) -> Result<()> {
+    let api_url = resolve_api_url(cli_api_url);
 
     if let Some(creds) = load_stored_credentials()? {
         println!("Already logged in as {}", creds.email);

--- a/binaries/statespace-cli/src/config.rs
+++ b/binaries/statespace-cli/src/config.rs
@@ -54,6 +54,7 @@ fn get_current_context(config: &ConfigFile) -> Option<&Context> {
 }
 
 pub(crate) fn resolve_credentials(
+    cli_api_url: Option<&str>,
     cli_api_key: Option<&str>,
     cli_org_id: Option<&str>,
 ) -> Result<Credentials> {
@@ -81,7 +82,10 @@ pub(crate) fn resolve_credentials(
     let cfg_key = context.and_then(|c| c.api_key.clone());
     let cfg_org = context.and_then(|c| c.org_id.clone());
 
-    let api_url = stored_url
+    let api_url = cli_api_url
+        .map(String::from)
+        .filter(|s| !s.trim().is_empty())
+        .or(stored_url)
         .or(cfg_url)
         .unwrap_or_else(|| DEFAULT_API_URL.to_string());
 
@@ -102,7 +106,10 @@ pub(crate) fn resolve_credentials(
     })
 }
 
-pub(crate) fn resolve_api_url() -> String {
+pub(crate) fn resolve_api_url(cli_api_url: Option<&str>) -> String {
+    if let Some(url) = cli_api_url.filter(|s| !s.trim().is_empty()) {
+        return url.to_string();
+    }
     let stored = load_stored_credentials().ok().flatten();
     let stored_url = stored.as_ref().map(|c| c.api_url.clone());
 

--- a/binaries/statespace-cli/src/main.rs
+++ b/binaries/statespace-cli/src/main.rs
@@ -25,16 +25,24 @@ async fn run() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Auth { command } => commands::auth::run(command).await,
+        Commands::Auth { command } => commands::auth::run(command, cli.api_url.as_deref()).await,
 
         Commands::Deploy(args) => {
-            let creds = resolve_credentials(cli.api_key.as_deref(), cli.org_id.as_deref())?;
+            let creds = resolve_credentials(
+                cli.api_url.as_deref(),
+                cli.api_key.as_deref(),
+                cli.org_id.as_deref(),
+            )?;
             let gateway = GatewayClient::new(creds)?;
             commands::app::run_create(args, gateway).await
         }
 
         Commands::Sync(args) => {
-            let creds = resolve_credentials(cli.api_key.as_deref(), cli.org_id.as_deref())?;
+            let creds = resolve_credentials(
+                cli.api_url.as_deref(),
+                cli.api_key.as_deref(),
+                cli.org_id.as_deref(),
+            )?;
             let gateway = GatewayClient::new(creds)?;
             commands::sync::run_sync(args, gateway).await
         }
@@ -42,14 +50,22 @@ async fn run() -> Result<()> {
         Commands::Serve(args) => commands::serve::run_serve(args).await,
 
         Commands::Org { command } => {
-            let creds = resolve_credentials(cli.api_key.as_deref(), cli.org_id.as_deref())?;
+            let creds = resolve_credentials(
+                cli.api_url.as_deref(),
+                cli.api_key.as_deref(),
+                cli.org_id.as_deref(),
+            )?;
             let gateway = GatewayClient::new(creds)?;
             commands::org::run(command, gateway).await
         }
 
         Commands::App { command } => {
             let build_gateway = || -> Result<GatewayClient> {
-                let creds = resolve_credentials(cli.api_key.as_deref(), cli.org_id.as_deref())?;
+                let creds = resolve_credentials(
+                    cli.api_url.as_deref(),
+                    cli.api_key.as_deref(),
+                    cli.org_id.as_deref(),
+                )?;
                 GatewayClient::new(creds)
             };
 
@@ -82,7 +98,11 @@ async fn run() -> Result<()> {
         }
 
         Commands::Tokens { command } => {
-            let creds = resolve_credentials(cli.api_key.as_deref(), cli.org_id.as_deref())?;
+            let creds = resolve_credentials(
+                cli.api_url.as_deref(),
+                cli.api_key.as_deref(),
+                cli.org_id.as_deref(),
+            )?;
             let gateway = GatewayClient::new(creds)?;
             commands::tokens::run(command, gateway).await
         }
@@ -91,7 +111,11 @@ async fn run() -> Result<()> {
             args::SshCommands::Setup { yes } => commands::ssh_config::run_setup(yes).await,
             args::SshCommands::Uninstall { yes } => commands::ssh_config::run_uninstall(yes),
             args::SshCommands::Keys { command } => {
-                let creds = resolve_credentials(cli.api_key.as_deref(), cli.org_id.as_deref())?;
+                let creds = resolve_credentials(
+                    cli.api_url.as_deref(),
+                    cli.api_key.as_deref(),
+                    cli.org_id.as_deref(),
+                )?;
                 let gateway = GatewayClient::new(creds)?;
                 commands::ssh_key::run(command, gateway).await
             }


### PR DESCRIPTION
Adds a global `--api-url` CLI flag and `STATESPACE_GATEWAY_URL` environment variable to override the gateway API URL. Threaded through `resolve_credentials` and `resolve_api_url` with precedence: CLI flag > env var > stored credentials > config file > default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global CLI option to specify a custom gateway API URL (can be set via env or flag).

* **Behavioral Change**
  * CLI-provided API URL now takes precedence when resolving credentials and is used across auth, deploy, sync, app, org, tokens, and SSH commands.

* **Refactor**
  * Command flows updated to consistently propagate the resolved API URL through credential resolution and command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->