### PR TITLE
fix(ci): include embedded template assets in Nix src in release workflow

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,8 @@
           src = ./.;
           filter = path: type:
             (craneLib.filterCargoSources path type) ||
+            # Keep embedded template assets referenced by include_str! in statespace-templates.
+            (builtins.match ".*crates/statespace-templates/src/.*\\.(md|svg|html)$" path != null) ||
             (builtins.match ".*\\.toml$" path != null) ||
             (builtins.match ".*\\.lock$" path != null);
         };


### PR DESCRIPTION
## Summary
Fixes release workflow failures where Nix builds could not find `statespace-templates` embedded files (`AGENTS.md`, `favicon.svg`, `index.html`).

## What Changed
- Updated `flake.nix` source filtering to include `crates/statespace-templates/src/*.md|*.svg|*.html`.
- Kept existing Cargo/TOML/lock filtering behavior.

## Why
The release workflow uses `nix build` in `build-release-binaries`. The previous `cleanSourceWith` filter excluded non-Rust extensions, so `include_str!` asset files were omitted from the build source and compilation failed. That caused downstream `host` and GitHub Release creation steps to be skipped.

## Validation
- `nix build .#statespace` ✅
- `cargo check` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed source filtering to properly include template assets (Markdown, SVG, and HTML files) in the distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->