### PR TITLE
fix: process eval blocks for all responses, not just HTML

### DIFF
--- a/crates/statespace-server/src/server.rs
+++ b/crates/statespace-server/src/server.rs
@@ -244,9 +244,10 @@ async fn serve_page(path: &str, headers: &HeaderMap, state: &ServerState) -> Res
         }
     };
 
+    let working_dir = file_path.parent().unwrap_or(&state.content_root);
+    let rendered = eval::process_eval_blocks(&content, working_dir, &state.env).await;
+
     if wants_html(headers) {
-        let working_dir = file_path.parent().unwrap_or(&state.content_root);
-        let rendered = eval::process_eval_blocks(&content, working_dir, &state.env).await;
         (
             [(header::VARY, "Accept, User-Agent")],
             Html(render_markdown_to_html(&rendered)),
@@ -258,7 +259,7 @@ async fn serve_page(path: &str, headers: &HeaderMap, state: &ServerState) -> Res
                 (header::CONTENT_TYPE, "text/markdown; charset=utf-8"),
                 (header::VARY, "Accept, User-Agent"),
             ],
-            content,
+            rendered,
         )
             .into_response()
     }


### PR DESCRIPTION
Component eval blocks were only executed when serving HTML to browsers. Programmatic clients (curl, agents) received raw markdown with unprocessed component blocks. Now eval blocks run regardless of output format.

## Summary

## Changes

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [ ] Docs updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized server response handling for page content across different formats (HTML and Markdown).
  * Page content is now evaluated once before formatting responses, ensuring consistent content delivery across response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->