### PR TITLE
fix: macOS binary crashes on machines without Nix

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -193,6 +193,15 @@ jobs:
           ARCHIVE="statespace-v${VERSION}-aarch64-apple-darwin"
           mkdir -p "dist/${ARCHIVE}"
           cp result/bin/statespace "dist/${ARCHIVE}/statespace"
+          chmod 755 "dist/${ARCHIVE}/statespace"
+
+          # Nix hardcodes dylib paths to /nix/store/...; rewrite them to
+          # the system-provided libraries so the binary works without Nix.
+          for lib in $(otool -L "dist/${ARCHIVE}/statespace" | awk '/\/nix\/store\// {print $1}'); do
+            base=$(basename "$lib")
+            install_name_tool -change "$lib" "/usr/lib/$base" "dist/${ARCHIVE}/statespace"
+          done
+
           tar -czvf "dist/${ARCHIVE}.tar.gz" -C dist "${ARCHIVE}"
           shasum -a 256 "dist/${ARCHIVE}.tar.gz" > "dist/${ARCHIVE}.tar.gz.sha256"
 


### PR DESCRIPTION
## Problem

When a user installs the CLI on macOS via the curl installer, it crashes immediately:

```
dyld[40555]: Library not loaded: /nix/store/7h6icyvqv6.../libiconv.2.dylib
  Referenced from: ...
  Reason: tried: '/nix/store/...' (no such file)
zsh: abort      statespace
```

## Cause

The macOS binary is built with Nix, which hardcodes library paths like `/nix/store/.../libiconv.2.dylib` into the binary. The binary then only works on machines that have Nix installed.

The Linux builds already fix this — the GNU builds use `patchelf --remove-rpath`, and the musl builds are fully static. The macOS build was missing an equivalent fix.

## Fix

After copying the binary, use `install_name_tool` to rewrite any `/nix/store/...` library references to `/usr/lib/...`. macOS ships `libiconv` (and other system libraries) at `/usr/lib/` on every Mac, so the binary will find them there.

The fix handles all Nix store references generically, not just `libiconv`, so it won't break if another Nix-provided library gets pulled in later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved macOS release packaging: ensures packaged binaries have correct executable permissions and rewrites embedded library references to point to system libraries before creating the release tarball. Tarball creation and checksum generation remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->