### PR TITLE
refactor: extract shared server semantics

### DIFF
--- a/crates/statespace-server/src/content.rs
+++ b/crates/statespace-server/src/content.rs
@@ -5,6 +5,8 @@ use statespace_tool_runtime::Error;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
+use crate::semantics::markdown_lookup_candidates;
+
 #[async_trait]
 pub trait ContentResolver: Send + Sync {
     async fn resolve(&self, path: &str) -> Result<String, Error>;
@@ -54,23 +56,12 @@ impl LocalContentResolver {
         Ok(target)
     }
 
-    fn resolve_to_file(target: &Path, original: &str) -> Result<PathBuf, Error> {
-        if target.is_file() {
-            return Ok(target.to_path_buf());
-        }
-
-        if target.is_dir() {
-            let readme = target.join("README.md");
-            if readme.is_file() {
-                return Ok(readme);
+    fn resolve_to_file(root: &Path, original: &str) -> Result<PathBuf, Error> {
+        for candidate in markdown_lookup_candidates(original) {
+            let candidate_path = root.join(candidate);
+            if candidate_path.is_file() {
+                return Ok(candidate_path);
             }
-            return Err(Error::NotFound(original.to_string()));
-        }
-
-        let mut with_md = target.to_path_buf();
-        with_md.set_extension("md");
-        if with_md.is_file() {
-            return Ok(with_md);
         }
 
         Err(Error::NotFound(original.to_string()))
@@ -80,8 +71,8 @@ impl LocalContentResolver {
 #[async_trait]
 impl ContentResolver for LocalContentResolver {
     async fn resolve(&self, path: &str) -> Result<String, Error> {
-        let target = self.validate_path(path)?;
-        let resolved = Self::resolve_to_file(&target, path)?;
+        self.validate_path(path)?;
+        let resolved = Self::resolve_to_file(&self.root, path)?;
 
         let resolved = resolved
             .canonicalize()
@@ -97,8 +88,8 @@ impl ContentResolver for LocalContentResolver {
     }
 
     async fn resolve_path(&self, path: &str) -> Result<PathBuf, Error> {
-        let target = self.validate_path(path)?;
-        let resolved = Self::resolve_to_file(&target, path)?;
+        self.validate_path(path)?;
+        let resolved = Self::resolve_to_file(&self.root, path)?;
 
         let resolved = resolved
             .canonicalize()
@@ -125,8 +116,11 @@ mod tests {
         let dir = TempDir::new().unwrap();
         write(dir.path().join("README.md"), "# Root README").unwrap();
         write(dir.path().join("file.md"), "# File").unwrap();
+        write(dir.path().join("no_readme.md"), "# No Readme File").unwrap();
+        write(dir.path().join("index.html"), "<h1>index</h1>").unwrap();
         std::fs::create_dir(dir.path().join("subdir")).unwrap();
         write(dir.path().join("subdir/README.md"), "# Subdir README").unwrap();
+        std::fs::create_dir(dir.path().join("no_readme")).unwrap();
         dir
     }
 
@@ -164,6 +158,24 @@ mod tests {
 
         let content = resolver.resolve("subdir").await.unwrap();
         assert!(content.contains("# Subdir README"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_subdir_without_readme_falls_back_to_sibling_markdown() {
+        let dir = setup_test_dir();
+        let resolver = LocalContentResolver::new(dir.path()).unwrap();
+
+        let content = resolver.resolve("no_readme").await.unwrap();
+        assert!(content.contains("# No Readme File"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_index_html_not_found() {
+        let dir = setup_test_dir();
+        let resolver = LocalContentResolver::new(dir.path()).unwrap();
+
+        let result = resolver.resolve("index.html").await;
+        assert!(matches!(result, Err(Error::NotFound(_))));
     }
 
     #[tokio::test]

--- a/crates/statespace-server/src/lib.rs
+++ b/crates/statespace-server/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod content;
 pub mod error;
 pub mod init;
+pub mod semantics;
 pub mod server;
 pub mod templates;
 

--- a/crates/statespace-server/src/semantics.rs
+++ b/crates/statespace-server/src/semantics.rs
@@ -1,0 +1,112 @@
+use crate::templates::render_page_html;
+use ammonia::Builder;
+use axum::http::{HeaderMap, header};
+use pulldown_cmark::{Options, Parser, html};
+use std::path::Path;
+
+const BROWSER_UA_KEYWORDS: &[&str] = &["Chrome/", "Safari/", "Firefox/", "Edg/", "Opera/", "OPR/"];
+
+#[must_use]
+pub fn is_browser_request(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ua| BROWSER_UA_KEYWORDS.iter().any(|kw| ua.contains(kw)))
+}
+
+#[must_use]
+pub fn wants_html(headers: &HeaderMap) -> bool {
+    let accept = headers
+        .get(header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_ascii_lowercase);
+
+    match accept.as_deref() {
+        Some(a) if a.contains("text/html") => true,
+        Some(a) if a.contains("text/markdown") || a.contains("text/plain") => false,
+        Some(a) if a.contains("*/*") => is_browser_request(headers),
+        Some(_) | None => is_browser_request(headers),
+    }
+}
+
+#[must_use]
+pub fn render_markdown_to_html(markdown: &str) -> String {
+    let options =
+        Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TASKLISTS;
+    let parser = Parser::new_ext(markdown, options);
+    let mut html_output = String::new();
+    html::push_html(&mut html_output, parser);
+    let sanitized = Builder::default().clean(&html_output).to_string();
+    render_page_html(&sanitized)
+}
+
+#[must_use]
+pub fn is_agents_request(path: &str) -> bool {
+    path == "AGENTS" || path == "AGENTS.md"
+}
+
+#[must_use]
+pub fn markdown_lookup_candidates(path: &str) -> Vec<String> {
+    let normalized = path.trim_start_matches('/');
+
+    if normalized.is_empty() {
+        return vec!["README.md".to_string()];
+    }
+
+    if normalized.ends_with('/') {
+        return vec![format!("{normalized}README.md")];
+    }
+
+    if Path::new(normalized)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+    {
+        return vec![normalized.to_string()];
+    }
+
+    vec![
+        format!("{normalized}/README.md"),
+        format!("{normalized}.md"),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markdown_candidates_for_root() {
+        assert_eq!(markdown_lookup_candidates(""), vec!["README.md"]);
+    }
+
+    #[test]
+    fn markdown_candidates_for_extensionless_path() {
+        assert_eq!(
+            markdown_lookup_candidates("docs/intro"),
+            vec!["docs/intro/README.md", "docs/intro.md"]
+        );
+    }
+
+    #[test]
+    fn markdown_candidates_for_explicit_markdown_file() {
+        assert_eq!(
+            markdown_lookup_candidates("docs/intro.md"),
+            vec!["docs/intro.md"]
+        );
+    }
+
+    #[test]
+    fn markdown_candidates_for_directory_path() {
+        assert_eq!(
+            markdown_lookup_candidates("docs/intro/"),
+            vec!["docs/intro/README.md"]
+        );
+    }
+
+    #[test]
+    fn agents_requests_are_explicit_only() {
+        assert!(is_agents_request("AGENTS"));
+        assert!(is_agents_request("AGENTS.md"));
+        assert!(!is_agents_request("agents"));
+    }
+}

--- a/crates/statespace-server/src/server.rs
+++ b/crates/statespace-server/src/server.rs
@@ -2,8 +2,10 @@
 
 use crate::content::{ContentResolver, LocalContentResolver};
 use crate::error::ErrorExt;
-use crate::templates::{FAVICON_SVG, OPENGRAPH_PNG, render_page_html};
-use ammonia::Builder;
+#[cfg(test)]
+use crate::semantics::is_browser_request;
+use crate::semantics::{render_markdown_to_html, wants_html};
+use crate::templates::{FAVICON_SVG, OPENGRAPH_PNG};
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -11,7 +13,6 @@ use axum::{
     response::{Html, IntoResponse, Response},
     routing::get,
 };
-use pulldown_cmark::{Options, Parser, html};
 use statespace_tool_runtime::{
     ActionRequest, ActionResponse, BuiltinTool, ExecutionLimits, ToolExecutor, eval,
     expand_env_vars, expand_placeholders, parse_frontmatter, validate_command_with_specs,
@@ -146,39 +147,6 @@ pub fn build_router(config: &ServerConfig) -> crate::error::Result<Router> {
         .with_state(state))
 }
 
-const BROWSER_UA_KEYWORDS: &[&str] = &["Chrome/", "Safari/", "Firefox/", "Edg/", "Opera/", "OPR/"];
-
-fn is_browser_request(headers: &HeaderMap) -> bool {
-    headers
-        .get(header::USER_AGENT)
-        .and_then(|v| v.to_str().ok())
-        .is_some_and(|ua| BROWSER_UA_KEYWORDS.iter().any(|kw| ua.contains(kw)))
-}
-
-fn wants_html(headers: &HeaderMap) -> bool {
-    let accept = headers
-        .get(header::ACCEPT)
-        .and_then(|v| v.to_str().ok())
-        .map(str::to_ascii_lowercase);
-
-    match accept.as_deref() {
-        Some(a) if a.contains("text/html") => true,
-        Some(a) if a.contains("text/markdown") || a.contains("text/plain") => false,
-        Some(a) if a.contains("*/*") => is_browser_request(headers),
-        Some(_) | None => is_browser_request(headers),
-    }
-}
-
-fn render_markdown_to_html(markdown: &str) -> String {
-    let options =
-        Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TASKLISTS;
-    let parser = Parser::new_ext(markdown, options);
-    let mut html_output = String::new();
-    html::push_html(&mut html_output, parser);
-    let sanitized = Builder::default().clean(&html_output).to_string();
-    render_page_html(&sanitized)
-}
-
 async fn index_handler(headers: HeaderMap, State(state): State<ServerState>) -> Response {
     serve_page("AGENTS.md", &headers, &state).await
 }
@@ -232,12 +200,34 @@ async fn serve_page(path: &str, headers: &HeaderMap, state: &ServerState) -> Res
     };
 
     let working_dir = file_path.parent().unwrap_or(&state.content_root);
+    let has_eval = !eval::parse_eval_blocks(&content).is_empty();
     let rendered = eval::process_eval_blocks(&content, working_dir, &state.env).await;
 
     if wants_html(headers) {
+        if has_eval {
+            (
+                [
+                    (header::CACHE_CONTROL, "no-store"),
+                    (header::VARY, "Accept, User-Agent"),
+                ],
+                Html(render_markdown_to_html(&rendered)),
+            )
+                .into_response()
+        } else {
+            (
+                [(header::VARY, "Accept, User-Agent")],
+                Html(render_markdown_to_html(&rendered)),
+            )
+                .into_response()
+        }
+    } else if has_eval {
         (
-            [(header::VARY, "Accept, User-Agent")],
-            Html(render_markdown_to_html(&rendered)),
+            [
+                (header::CONTENT_TYPE, "text/markdown; charset=utf-8"),
+                (header::CACHE_CONTROL, "no-store"),
+                (header::VARY, "Accept, User-Agent"),
+            ],
+            rendered,
         )
             .into_response()
     } else {
@@ -462,5 +452,28 @@ mod tests {
         let result = render_markdown_to_html("<script>alert('xss')</script>");
         assert!(!result.contains("<script>"));
         assert!(!result.contains("alert('xss')"));
+    }
+
+    #[tokio::test]
+    async fn eval_pages_set_no_store_cache_control() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("README.md"),
+            "```component\necho hello\n```\n",
+        )
+        .unwrap();
+
+        let config = ServerConfig::new(dir.path().to_path_buf());
+        let state = ServerState::from_config(&config).unwrap();
+        let headers = headers_with_accept("text/markdown");
+
+        let response = serve_page("README.md", &headers, &state).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let cache_control = response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(cache_control, Some("no-store"));
     }
 }


### PR DESCRIPTION
This extracts a lot of duplicated logic for the `serve` semantics into a light reusable module.