### PR TITLE
Parse structured JSON errors from gateway API responses

### DIFF
--- a/binaries/statespace-cli/src/error.rs
+++ b/binaries/statespace-cli/src/error.rs
@@ -39,7 +39,6 @@ pub(crate) enum ConfigError {
 }
 
 #[derive(Debug, Error)]
-#[allow(dead_code)]
 pub(crate) enum GatewayError {
     #[error("Failed to build HTTP client: {0}")]
     ClientBuild(String),
@@ -50,9 +49,6 @@ pub(crate) enum GatewayError {
     #[error("API error ({status}): {message}")]
     Api { status: u16, message: String },
 
-    #[error("Failed to parse response: {0}")]
-    Parse(String),
-
     #[error("Authentication required. Run `statespace auth login`.")]
     Unauthorized,
 
@@ -61,6 +57,27 @@ pub(crate) enum GatewayError {
 
     #[error("Organization ID required. Run `statespace auth login` again or pass `--org-id`.")]
     MissingOrgId,
+}
+
+impl GatewayError {
+    pub(crate) fn from_response(status: u16, body: &str) -> Self {
+        let message = serde_json::from_str::<serde_json::Value>(body)
+            .ok()
+            .and_then(|v| {
+                v.get("error")
+                    .and_then(|e| e.get("message"))
+                    .or_else(|| v.get("message"))
+                    .and_then(|m| m.as_str())
+                    .map(String::from)
+            })
+            .unwrap_or_else(|| body.chars().take(512).collect());
+
+        match status {
+            401 => Self::Unauthorized,
+            404 => Self::NotFound(message),
+            _ => Self::Api { status, message },
+        }
+    }
 }
 
 impl From<reqwest::Error> for GatewayError {

--- a/binaries/statespace-cli/src/gateway/client.rs
+++ b/binaries/statespace-cli/src/gateway/client.rs
@@ -383,16 +383,11 @@ pub(super) async fn check_api_response(resp: reqwest::Response) -> Result<()> {
         return Ok(());
     }
 
-    let text = resp
+    let body = resp
         .text()
         .await
         .unwrap_or_else(|e| format!("(failed to read body: {e})"));
-    let message = text.chars().take(512).collect();
-    Err(GatewayError::Api {
-        status: status.as_u16(),
-        message,
-    }
-    .into())
+    Err(GatewayError::from_response(status.as_u16(), &body).into())
 }
 
 pub(super) async fn parse_api_response<T: serde::de::DeserializeOwned>(
@@ -405,12 +400,7 @@ pub(super) async fn parse_api_response<T: serde::de::DeserializeOwned>(
         .unwrap_or_else(|e| format!("(failed to read body: {e})"));
 
     if !status.is_success() {
-        let message = text.chars().take(512).collect();
-        return Err(GatewayError::Api {
-            status: status.as_u16(),
-            message,
-        }
-        .into());
+        return Err(GatewayError::from_response(status.as_u16(), &text).into());
     }
 
     let status_code = status.as_u16();
@@ -441,12 +431,7 @@ async fn parse_api_list_response<T: serde::de::DeserializeOwned>(
         .unwrap_or_else(|e| format!("(failed to read body: {e})"));
 
     if !status.is_success() {
-        let message = text.chars().take(512).collect();
-        return Err(GatewayError::Api {
-            status: status_code,
-            message,
-        }
-        .into());
+        return Err(GatewayError::from_response(status_code, &text).into());
     }
 
     let value: Value = serde_json::from_str(&text).map_err(|e| GatewayError::Api {


### PR DESCRIPTION
## Problem

The gateway now returns structured error JSON instead of bare status codes:
```json
{"error": {"code": "CONFLICT", "message": "Application name already taken: foo"}}
```

The CLI wasn't parsing this — users saw empty or unhelpful messages:
```
error: API error (400):
error: API error (409):
error: API error (401):
```

## After

```
error: A root-level README.md file is required for deployment
error: API error (409): Application name already taken: foo
error: Authentication required. Run `statespace auth login`.
error: Not found: environment
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized API error construction for consistent, clearer error messages.
  * Error responses now map common HTTP statuses to specific, user-facing messages (e.g., unauthorized, not found) and extract concise messages from response bodies.
  * Removed obsolete internal code paths to streamline error handling and reduce noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->