### PR TITLE
feat: inject query params into statespace serve eval env

### DIFF
--- a/binaries/statespace-cli/src/commands/serve.rs
+++ b/binaries/statespace-cli/src/commands/serve.rs
@@ -24,12 +24,16 @@ pub(crate) async fn run_serve(args: ServeArgs) -> Result<()> {
     initialize_templates(&config.content_root).await?;
 
     let addr = config.socket_addr();
-    let base_url = config.base_url();
     let router =
         build_router(&config).map_err(|e| Error::cli(format!("Failed to build router: {e}")))?;
 
     let listener = TcpListener::bind(&addr).await?;
-    eprintln!("Serving on {base_url}");
+    let local_addr = listener.local_addr()?;
+    eprintln!(
+        "Serving on http://{}:{}",
+        local_addr.ip(),
+        local_addr.port()
+    );
 
     axum::serve(listener, router)
         .await

--- a/binaries/statespace-cli/tests/serve_query_env_integration.rs
+++ b/binaries/statespace-cli/tests/serve_query_env_integration.rs
@@ -1,6 +1,8 @@
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::time::Duration;
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::{Duration, Instant};
 
 type TestResult<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -13,11 +15,6 @@ impl Drop for ChildGuard {
         if let Err(_error) = self.child.kill() {}
         if let Err(_error) = self.child.wait() {}
     }
-}
-
-fn pick_free_port() -> TestResult<u16> {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-    Ok(listener.local_addr()?.port())
 }
 
 fn statespace_bin_path() -> TestResult<PathBuf> {
@@ -37,7 +34,54 @@ fn statespace_bin_path() -> TestResult<PathBuf> {
     Ok(bin)
 }
 
-fn spawn_server(content_dir: &Path, port: u16, extra_args: &[&str]) -> TestResult<ChildGuard> {
+fn wait_for_base_url(child: &mut Child) -> TestResult<String> {
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| std::io::Error::other("failed to capture server stderr"))?;
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let reader = std::io::BufReader::new(stderr);
+        for line in reader.lines() {
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Err(
+                std::io::Error::other(format!("server exited before startup: {status}")).into(),
+            );
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(std::io::Error::other("timed out waiting for server startup").into());
+        }
+
+        let remaining = deadline.saturating_duration_since(now);
+        match rx.recv_timeout(remaining.min(Duration::from_millis(100))) {
+            Ok(Ok(line)) => {
+                if let Some(base_url) = line.trim().strip_prefix("Serving on ") {
+                    return Ok(base_url.to_string());
+                }
+            }
+            Ok(Err(error)) => return Err(error.into()),
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(
+                    std::io::Error::other("server output closed before startup message").into(),
+                );
+            }
+        }
+    }
+}
+
+fn spawn_server(content_dir: &Path, extra_args: &[&str]) -> TestResult<(ChildGuard, String)> {
     let bin = statespace_bin_path()?;
 
     let mut cmd = Command::new(bin);
@@ -46,14 +90,15 @@ fn spawn_server(content_dir: &Path, port: u16, extra_args: &[&str]) -> TestResul
         .arg("--host")
         .arg("127.0.0.1")
         .arg("--port")
-        .arg(port.to_string())
+        .arg("0")
         .args(extra_args)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::piped());
 
-    let child = cmd.spawn()?;
-    Ok(ChildGuard { child })
+    let mut child = cmd.spawn()?;
+    let base_url = wait_for_base_url(&mut child)?;
+    Ok((ChildGuard { child }, base_url))
 }
 
 async fn wait_until_ready(base_url: &str) -> TestResult {
@@ -80,9 +125,7 @@ async fn statespace_serve_injects_query_params_into_component_blocks() -> TestRe
         "```component\nprintf '%s/%s' \"$USER_ID\" \"$PAGE\"\n```\n",
     )?;
 
-    let port = pick_free_port()?;
-    let base_url = format!("http://127.0.0.1:{port}");
-    let _server = spawn_server(dir.path(), port, &[])?;
+    let (_server, base_url) = spawn_server(dir.path(), &[])?;
     wait_until_ready(&base_url).await?;
 
     let body = reqwest::get(format!("{base_url}/README.md?USER_ID=42&PAGE=stats"))
@@ -102,9 +145,7 @@ async fn statespace_serve_trusted_env_overrides_query_params() -> TestResult {
         "```component\necho \"$USER_ID\"\n```\n",
     )?;
 
-    let port = pick_free_port()?;
-    let base_url = format!("http://127.0.0.1:{port}");
-    let _server = spawn_server(dir.path(), port, &["--env", "USER_ID=trusted"])?;
+    let (_server, base_url) = spawn_server(dir.path(), &["--env", "USER_ID=trusted"])?;
     wait_until_ready(&base_url).await?;
 
     let body = reqwest::get(format!("{base_url}/README.md?USER_ID=untrusted"))
@@ -124,9 +165,7 @@ async fn statespace_serve_rejects_reserved_query_keys() -> TestResult {
         "```component\necho \"$HOME\"\n```\n",
     )?;
 
-    let port = pick_free_port()?;
-    let base_url = format!("http://127.0.0.1:{port}");
-    let _server = spawn_server(dir.path(), port, &[])?;
+    let (_server, base_url) = spawn_server(dir.path(), &[])?;
     wait_until_ready(&base_url).await?;
 
     let body = reqwest::get(format!("{base_url}/README.md?HOME=%2Fevil"))
@@ -135,5 +174,18 @@ async fn statespace_serve_rejects_reserved_query_keys() -> TestResult {
         .await?;
 
     assert_eq!(body.trim(), "/tmp");
+    Ok(())
+}
+
+#[tokio::test]
+async fn statespace_serve_rejects_malformed_query_env_entries() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    std::fs::write(dir.path().join("README.md"), "ok\n")?;
+
+    let (_server, base_url) = spawn_server(dir.path(), &[])?;
+    wait_until_ready(&base_url).await?;
+
+    let response = reqwest::get(format!("{base_url}/README.md?A%3DB=1")).await?;
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
     Ok(())
 }

--- a/crates/statespace-server/src/server.rs
+++ b/crates/statespace-server/src/server.rs
@@ -187,12 +187,22 @@ async fn file_handler(
     serve_page(&path, &headers, &query_env, &state).await
 }
 
+fn has_invalid_query_env_entry(query_env: &HashMap<String, String>) -> bool {
+    query_env.iter().any(|(key, value)| {
+        key.is_empty() || key.contains('=') || key.contains('\0') || value.contains('\0')
+    })
+}
+
 async fn serve_page(
     path: &str,
     headers: &HeaderMap,
     query_env: &HashMap<String, String>,
     state: &ServerState,
 ) -> Response {
+    if has_invalid_query_env_entry(query_env) {
+        return (StatusCode::BAD_REQUEST, "Invalid query parameter").into_response();
+    }
+
     let file_path = match state.content_resolver.resolve_path(path).await {
         Ok(p) => p,
         Err(e) => {
@@ -535,5 +545,33 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(String::from_utf8_lossy(&body), "trusted");
+    }
+
+    #[tokio::test]
+    async fn invalid_query_key_returns_bad_request() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("README.md"), "ok\n").unwrap();
+
+        let config = ServerConfig::new(dir.path().to_path_buf());
+        let state = ServerState::from_config(&config).unwrap();
+        let headers = headers_with_accept("text/markdown");
+        let query = HashMap::from([("A=B".to_string(), "1".to_string())]);
+
+        let response = serve_page("README.md", &headers, &query, &state).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn invalid_query_value_returns_bad_request() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("README.md"), "ok\n").unwrap();
+
+        let config = ServerConfig::new(dir.path().to_path_buf());
+        let state = ServerState::from_config(&config).unwrap();
+        let headers = headers_with_accept("text/markdown");
+        let query = HashMap::from([("USER_ID".to_string(), "abc\0def".to_string())]);
+
+        let response = serve_page("README.md", &headers, &query, &state).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/statespace-tool-runtime/src/eval.rs
+++ b/crates/statespace-tool-runtime/src/eval.rs
@@ -103,7 +103,13 @@ fn is_eval_info_string(info: &str) -> bool {
 }
 
 const RESERVED_ENV_PREFIXES: &[&str] = &["AWS_", "LD_", "DYLD_", "_LAMBDA", "_HANDLER"];
-const RESERVED_ENV_KEYS: &[&str] = &["HOME", "LANG", "STATESPACE_SCRATCH", "STATESPACE_WORKSPACE"];
+const RESERVED_ENV_KEYS: &[&str] = &[
+    "HOME",
+    "LANG",
+    "PATH",
+    "STATESPACE_SCRATCH",
+    "STATESPACE_WORKSPACE",
+];
 
 fn is_reserved_env_key(key: &str) -> bool {
     RESERVED_ENV_KEYS.contains(&key) || RESERVED_ENV_PREFIXES.iter().any(|p| key.starts_with(p))
@@ -573,10 +579,14 @@ mod tests {
         use crate::eval::merge_eval_env;
 
         let trusted = HashMap::from([("AWS_SECRET_ACCESS_KEY".to_string(), "x".to_string())]);
-        let untrusted = HashMap::from([("LD_PRELOAD".to_string(), "y".to_string())]);
+        let untrusted = HashMap::from([
+            ("LD_PRELOAD".to_string(), "y".to_string()),
+            ("PATH".to_string(), "/tmp/evil".to_string()),
+        ]);
 
         let merged = merge_eval_env(&trusted, &untrusted);
         assert!(!merged.contains_key("AWS_SECRET_ACCESS_KEY"));
         assert!(!merged.contains_key("LD_PRELOAD"));
+        assert!(!merged.contains_key("PATH"));
     }
 }


### PR DESCRIPTION
- add `merge_eval_env` to `statespace-tool-runtime::eval` so untrusted query params are filtered and trusted env values win on key collisions
- pass GET query params through `statespace-server` markdown handlers into component eval execution
- add integration coverage for real `statespace serve` behavior: query param injection, trusted override, and reserved-key filtering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query parameters in URLs can be injected into page components during rendering.
  * Server-configured environment variables override query parameters.
  * Reserved environment keys are protected from being overridden.

* **Tests**
  * Added integration tests covering query injection, environment precedence, and reserved-key protection.

* **Other**
  * Server startup now logs the actual bound address (host:port) for the running instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->