### PR TITLE
feat(cli): hide SSH commands behind feature flag

### DIFF
--- a/binaries/statespace-cli/Cargo.toml
+++ b/binaries/statespace-cli/Cargo.toml
@@ -12,6 +12,10 @@ description = "Statespace command-line interface"
 name = "statespace"
 path = "src/main.rs"
 
+[features]
+default = []
+ssh = []
+
 [dependencies]
 clap = { workspace = true }
 dirs = { workspace = true }

--- a/binaries/statespace-cli/src/args.rs
+++ b/binaries/statespace-cli/src/args.rs
@@ -42,6 +42,7 @@ pub(crate) enum Commands {
     Serve(ServeArgs),
 
     /// SSH configuration management
+    #[cfg(feature = "ssh")]
     Ssh {
         #[command(subcommand)]
         command: SshCommands,
@@ -105,9 +106,11 @@ pub(crate) enum AppCommands {
     Delete(AppDeleteArgs),
 
     /// SSH into an application
+    #[cfg(feature = "ssh")]
     Ssh(AppSshArgs),
 }
 
+#[cfg(feature = "ssh")]
 #[derive(Debug, Parser)]
 pub(crate) struct AppSshArgs {
     /// Application ID or name
@@ -194,6 +197,7 @@ pub(crate) struct AppDeleteArgs {
     pub yes: bool,
 }
 
+#[cfg(feature = "ssh")]
 #[derive(Debug, Subcommand)]
 pub(crate) enum SshKeyCommands {
     /// List your SSH public keys
@@ -217,6 +221,7 @@ pub(crate) enum SshKeyCommands {
     },
 }
 
+#[cfg(feature = "ssh")]
 #[derive(Debug, Subcommand)]
 pub(crate) enum SshCommands {
     /// Configure SSH for native scp/rsync/ssh access

--- a/binaries/statespace-cli/src/commands/auth.rs
+++ b/binaries/statespace-cli/src/commands/auth.rs
@@ -1,11 +1,10 @@
 use crate::args::{AuthCommands, TokenOutputFormat};
-use crate::commands::ssh_config;
 use crate::config::{
-    Credentials, StoredCredentials, credentials_path, delete_stored_credentials,
-    load_stored_credentials, resolve_api_url, save_stored_credentials,
+    StoredCredentials, credentials_path, delete_stored_credentials, load_stored_credentials,
+    resolve_api_url, save_stored_credentials,
 };
 use crate::error::Result;
-use crate::gateway::{AuthClient, DeviceTokenResponse, GatewayClient};
+use crate::gateway::{AuthClient, DeviceTokenResponse};
 use std::io::{self, Write};
 use std::time::Duration;
 
@@ -88,23 +87,6 @@ async fn run_login(cli_api_url: Option<&str>) -> Result<()> {
                 println!("✓ Logged in as {}", creds.email);
                 println!();
                 println!("Credentials saved to {}", credentials_path().display());
-
-                println!();
-                println!("SSH Access Setup");
-                println!("────────────────");
-
-                let gateway_creds = Credentials {
-                    api_url: creds.api_url.clone(),
-                    api_key: creds.api_key.clone(),
-                    org_id: Some(creds.org_id.clone()),
-                };
-
-                if let Ok(gateway) = GatewayClient::new(gateway_creds) {
-                    if let Err(e) = ssh_config::setup_ssh_full(&gateway, false).await {
-                        eprintln!("Note: SSH setup failed: {e}");
-                        eprintln!("You can run 'statespace ssh setup' later.");
-                    }
-                }
 
                 return Ok(());
             }

--- a/binaries/statespace-cli/src/commands/mod.rs
+++ b/binaries/statespace-cli/src/commands/mod.rs
@@ -2,8 +2,11 @@ pub(crate) mod app;
 pub(crate) mod auth;
 pub(crate) mod secrets;
 pub(crate) mod serve;
+#[cfg(feature = "ssh")]
 pub(crate) mod ssh;
+#[cfg(feature = "ssh")]
 pub(crate) mod ssh_config;
+#[cfg(feature = "ssh")]
 pub(crate) mod ssh_key;
 pub(crate) mod sync;
 pub(crate) mod tokens;

--- a/binaries/statespace-cli/src/gateway/client.rs
+++ b/binaries/statespace-cli/src/gateway/client.rs
@@ -4,6 +4,7 @@ use crate::gateway::applications::{
     Application, ApplicationFile, DeployResult, UpsertResult, Visibility,
 };
 use crate::gateway::auth::{DeviceCodeResponse, DeviceTokenResponse};
+#[cfg(feature = "ssh")]
 use crate::gateway::ssh::SshKey;
 use crate::gateway::tokens::{Token, TokenCreateResult};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
@@ -49,6 +50,7 @@ impl GatewayClient {
         format!("Bearer {}", self.api_key)
     }
 
+    #[cfg(feature = "ssh")]
     pub(crate) fn base_url(&self) -> &str {
         &self.base_url
     }
@@ -331,6 +333,7 @@ impl GatewayClient {
         check_api_response(resp).await
     }
 
+    #[cfg(feature = "ssh")]
     pub(crate) async fn add_ssh_key(&self, name: &str, public_key: &str) -> Result<SshKey> {
         #[derive(Serialize)]
         struct Payload<'a> {
@@ -348,12 +351,14 @@ impl GatewayClient {
         parse_api_response(resp).await
     }
 
+    #[cfg(feature = "ssh")]
     pub(crate) async fn list_ssh_keys(&self) -> Result<Vec<SshKey>> {
         let url = format!("{}/api/v1/ssh-keys", self.base_url);
         let resp = self.with_headers(self.http.get(&url)).send().await?;
         parse_api_list_response(resp).await
     }
 
+    #[cfg(feature = "ssh")]
     pub(crate) async fn remove_ssh_key(&self, fingerprint: &str) -> Result<()> {
         let url = format!(
             "{}/api/v1/ssh-keys/{}",

--- a/binaries/statespace-cli/src/gateway/mod.rs
+++ b/binaries/statespace-cli/src/gateway/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod applications;
 mod auth;
 mod client;
 mod secrets;
+#[cfg(feature = "ssh")]
 mod ssh;
 mod tokens;
 

--- a/binaries/statespace-cli/src/main.rs
+++ b/binaries/statespace-cli/src/main.rs
@@ -46,6 +46,7 @@ async fn run() -> Result<()> {
             AppCommands::List => commands::app::run_list(build_gateway()?).await,
             AppCommands::Get(args) => commands::app::run_get(args, build_gateway()?).await,
             AppCommands::Delete(args) => commands::app::run_delete(args, build_gateway()?).await,
+            #[cfg(feature = "ssh")]
             AppCommands::Ssh(args) => commands::ssh::run_ssh(args, build_gateway()?).await,
         },
 
@@ -53,6 +54,7 @@ async fn run() -> Result<()> {
 
         Commands::Secrets { command } => commands::secrets::run(command, build_gateway()?).await,
 
+        #[cfg(feature = "ssh")]
         Commands::Ssh { command } => match command {
             args::SshCommands::Setup { yes } => commands::ssh_config::run_setup(yes).await,
             args::SshCommands::Uninstall { yes } => commands::ssh_config::run_uninstall(yes),


### PR DESCRIPTION
SSH and persistent compute are invite-only beta features. This PR hides all SSH-related functionality behind a feature flag.

## Changes

- Removed SSH setup message from `auth login` flow
- Added `ssh` Cargo feature flag to conditionally compile SSH commands
- SSH commands (`ssh`, `app ssh`, `ssh keys`) only available when built with `--features ssh`

## Usage

Default builds exclude SSH entirely:
```bash
cargo build --release
./target/release/statespace --help  # No ssh command listed
```

Beta users can enable SSH support:
```bash
cargo build --release --features ssh
./target/release/statespace --help  # ssh command available
```