### PR TITLE
Unify APP reference wording in CLI and docs

### DIFF
--- a/binaries/statespace-cli/src/args.rs
+++ b/binaries/statespace-cli/src/args.rs
@@ -117,9 +117,9 @@ pub(crate) struct AppSshArgs {
     #[arg(value_name = "APP")]
     pub app: String,
 
-    /// SSH user (default: app)
-    #[arg(long, short, default_value = "app")]
-    pub user: String,
+    /// SSH user override (default: application slug)
+    #[arg(long, short)]
+    pub user: Option<String>,
 
     /// SSH port (default: 22)
     #[arg(long, short, default_value = "22")]

--- a/binaries/statespace-cli/src/commands/ssh.rs
+++ b/binaries/statespace-cli/src/commands/ssh.rs
@@ -21,18 +21,24 @@ fn ssh_host_from_api_url(api_url: &str) -> String {
 }
 
 pub(crate) async fn run_ssh(args: AppSshArgs, gateway: GatewayClient) -> Result<()> {
-    let reference = normalize_application_reference(&args.app).map_err(Error::cli)?;
+    let AppSshArgs { app, user, port } = args;
+
+    let reference = normalize_application_reference(&app).map_err(Error::cli)?;
     let app = gateway.get_application(&reference).await?;
 
     let slug = &app.name;
     let ssh_host = ssh_host_from_api_url(gateway.base_url());
+    let ssh_user = user.unwrap_or_else(|| slug.clone());
+    let ssh_target = format!("{ssh_user}@{ssh_host}");
 
-    eprintln!("Connecting to {slug}@{ssh_host}");
+    eprintln!("Connecting to {ssh_target}");
 
     let status = Command::new("ssh")
         .args(["-o", "StrictHostKeyChecking=no"])
         .args(["-o", "UserKnownHostsFile=/dev/null"])
-        .arg(format!("{slug}@{ssh_host}"))
+        .arg("-p")
+        .arg(port.to_string())
+        .arg(&ssh_target)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())

--- a/docs/pages/reference/cli.md
+++ b/docs/pages/reference/cli.md
@@ -231,7 +231,7 @@ statespace app get <APP>
 **Arguments:**
 
 `APP`
-: Environment name, ID, or URL
+: Application name, ID, or URL
 
 ### `statespace app delete`
 
@@ -244,7 +244,7 @@ statespace app delete [OPTIONS] <APP>
 **Arguments:**
 
 `APP`
-: Environment name, ID, or URL
+: Application name, ID, or URL
 
 **Options:**
 
@@ -262,12 +262,12 @@ statespace app ssh <APP>
 **Arguments:**
 
 `APP`
-: Environment name, ID, or URL
+: Application name, ID, or URL
 
 **Options:**
 
 `--user, -u`
-: SSH user (default: `app`)
+: SSH user (default: application slug)
 
 `--port, -p`
 : SSH port (default: `22`)


### PR DESCRIPTION
Standardize app-targeting command docs/help to use `<APP>`.

`APP` here means any of:

- name (slug)
- ID (UUID)
- URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH command accepts an optional user and explicit port; target display now shows the resolved user@host.
* **Documentation**
  * Updated CLI help and reference to use APP placeholder and clarify that application name, ID, or URL are accepted.
  * CLI examples and usage updated to reflect new SSH behavior and argument names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->