### PR TITLE
feat(cli): deploy all files from project directory

### DIFF
--- a/binaries/statespace-cli/src/commands/sync.rs
+++ b/binaries/statespace-cli/src/commands/sync.rs
@@ -117,10 +117,10 @@ pub(crate) async fn run_sync(args: AppSyncArgs, gateway: impl SyncGateway) -> Re
             let cached = load_state(&dir)?;
             let target = resolve_target(args.name, cached.as_ref());
 
-            let files = GatewayClient::scan_markdown_files(&dir)?;
+            let files = GatewayClient::scan_deploy_files(&dir)?;
 
             if files.is_empty() {
-                eprintln!("No .md files found in {}", dir.display());
+                eprintln!("No files found in {}", dir.display());
                 return Ok(());
             }
 
@@ -417,6 +417,36 @@ mod tests {
             .expect("state exists");
         assert_eq!(state.name, "cached-app");
         assert_eq!(state.deployment_id, "id-1");
+    }
+
+    #[tokio::test]
+    async fn sync_with_path_uploads_non_markdown_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("assets")).expect("create assets dir");
+        std::fs::write(dir.path().join("README.md"), "# Updated").expect("write readme");
+        std::fs::write(dir.path().join("assets/config.json"), "{\"enabled\":true}")
+            .expect("write json");
+
+        let (mock, create_calls, upsert_calls) =
+            MockSyncGateway::new(deploy_result("bar"), upsert_result(false, "bar"));
+
+        let args = AppSyncArgs {
+            path: Some(dir.path().to_path_buf()),
+            name: Some("bar".to_string()),
+            visibility: None,
+        };
+
+        run_sync(args, mock).await.expect("run_sync");
+
+        let recorded_creates = create_calls.lock().expect("lock");
+        assert_eq!(recorded_creates.len(), 1);
+        let uploaded_paths: Vec<&str> = recorded_creates[0]
+            .1
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect();
+        assert_eq!(uploaded_paths, vec!["README.md", "assets/config.json"]);
+        assert!(upsert_calls.lock().expect("lock").is_empty());
     }
 
     #[tokio::test]

--- a/binaries/statespace-cli/src/gateway/client.rs
+++ b/binaries/statespace-cli/src/gateway/client.rs
@@ -12,7 +12,7 @@ use reqwest::Client;
 use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::path::Path;
+use std::path::{Component, Path};
 use std::time::Duration;
 
 const USER_AGENT: &str = concat!("statespace-cli/", env!("CARGO_PKG_VERSION"));
@@ -71,14 +71,11 @@ impl GatewayClient {
         }
     }
 
-    pub(crate) fn scan_markdown_files(dir: &Path) -> Result<Vec<ApplicationFile>> {
+    pub(crate) fn scan_deploy_files(dir: &Path) -> Result<Vec<ApplicationFile>> {
         let mut files = Vec::new();
 
         for path in collect_files(dir)? {
             if !path.is_file() {
-                continue;
-            }
-            if path.extension().and_then(|s| s.to_str()) != Some("md") {
                 continue;
             }
 
@@ -342,9 +339,27 @@ impl GatewayClient {
     }
 }
 
+fn is_ignored_deploy_path(root: &Path, path: &Path) -> bool {
+    const IGNORED_DIRS: [&str; 2] = [".git", ".statespace"];
+
+    let Ok(relative) = path.strip_prefix(root) else {
+        return false;
+    };
+
+    relative.components().any(|component| match component {
+        Component::Normal(name) => IGNORED_DIRS
+            .iter()
+            .any(|ignored| name == std::ffi::OsStr::new(ignored)),
+        _ => false,
+    })
+}
+
 fn collect_files(dir: &Path) -> Result<Vec<std::path::PathBuf>> {
     let mut results = Vec::new();
-    for entry in walkdir::WalkDir::new(dir) {
+    for entry in walkdir::WalkDir::new(dir)
+        .into_iter()
+        .filter_entry(|entry| !is_ignored_deploy_path(dir, entry.path()))
+    {
         let entry = entry
             .map_err(|e| crate::error::Error::cli(format!("Failed to walk directory: {e}")))?;
         if entry.file_type().is_file() {
@@ -496,5 +511,56 @@ impl AuthClient {
             .await?;
 
         parse_api_response(resp).await
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &TempDir, rel_path: &str, bytes: &[u8]) {
+        let path = dir.path().join(rel_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent directory");
+        }
+        std::fs::write(path, bytes).expect("write file");
+    }
+
+    #[test]
+    fn scan_deploy_files_includes_non_markdown_files() {
+        let dir = TempDir::new().expect("tempdir");
+        write_file(&dir, "README.md", b"# Hello");
+        write_file(&dir, "assets/logo.bin", &[0, 1, 2, 3]);
+        write_file(&dir, "data/config.json", br#"{"key":"value"}"#);
+
+        let files = GatewayClient::scan_deploy_files(dir.path()).expect("scan files");
+        let paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
+
+        assert_eq!(
+            paths,
+            vec!["README.md", "assets/logo.bin", "data/config.json"]
+        );
+
+        let logo = files
+            .iter()
+            .find(|file| file.path == "assets/logo.bin")
+            .expect("logo file should be present");
+        let decoded = BASE64.decode(&logo.content).expect("decode base64 content");
+        assert_eq!(decoded, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn scan_deploy_files_excludes_internal_metadata_directories() {
+        let dir = TempDir::new().expect("tempdir");
+        write_file(&dir, "README.md", b"# Hello");
+        write_file(&dir, ".statespace/state.json", br#"{"name":"demo"}"#);
+        write_file(&dir, ".git/config", b"[core]");
+
+        let files = GatewayClient::scan_deploy_files(dir.path()).expect("scan files");
+        let paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
+
+        assert_eq!(paths, vec!["README.md"]);
     }
 }


### PR DESCRIPTION
## Summary
This changes CLI sync/deploy file scanning to upload all files, not only `.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sync functionality now includes all deploy files, not limited to markdown documents
  * Internal metadata directories are automatically excluded during sync operations

* **Tests**
  * Added comprehensive test coverage for multi-file sync scenarios and non-markdown file handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->