### PR TITLE
feat: rename API.md to llms.txt everywhere

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ statespace/
 │       └── src/
 │           ├── lib.rs
 │           ├── AGENTS.md           # Written to new projects — guides coding agents building/iterating on the app
-│           ├── API.md              # Written to new projects — served at GET / of deployed apps; describes the HTTP API contract to consuming agents
+│           ├── llms.txt            # Written to new projects — served at GET / of deployed apps; describes the HTTP API contract to consuming agents
 │           ├── .gitignore
 │           └── starters/           # Per-database starter projects
 └── docs/

--- a/binaries/statespace-cli/src/commands/init.rs
+++ b/binaries/statespace-cli/src/commands/init.rs
@@ -1,7 +1,7 @@
 use crate::args::InitArgs;
 use crate::error::{Error, Result};
 use inquire::Confirm;
-use statespace_templates::{AGENTS_MD, API_MD, GITIGNORE, README_MD};
+use statespace_templates::{AGENTS_MD, GITIGNORE, LLMS_TXT, README_MD};
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
@@ -94,8 +94,8 @@ pub(crate) fn run_init(args: &InitArgs) -> Result<()> {
         created.push("CLAUDE.md");
     }
 
-    if write_if_confirmed(&output.join("API.md"), API_MD, args.yes)? {
-        created.push("API.md");
+    if write_if_confirmed(&output.join("llms.txt"), LLMS_TXT, args.yes)? {
+        created.push("llms.txt");
     }
 
     if merge_gitignore(&output.join(".gitignore"), GITIGNORE)? {
@@ -133,7 +133,7 @@ mod tests {
         assert!(dir.path().join("README.md").exists());
         assert!(dir.path().join("AGENTS.md").exists());
         assert!(dir.path().join("CLAUDE.md").exists());
-        assert!(dir.path().join("API.md").exists());
+        assert!(dir.path().join("llms.txt").exists());
         assert!(dir.path().join(".gitignore").exists());
         assert!(!dir.path().join("Dockerfile").exists());
     }
@@ -167,7 +167,7 @@ mod tests {
         assert!(dir.path().join("README.md").exists());
         assert!(dir.path().join("AGENTS.md").exists());
         assert!(dir.path().join("CLAUDE.md").exists());
-        assert!(dir.path().join("API.md").exists());
+        assert!(dir.path().join("llms.txt").exists());
         assert!(dir.path().join(".gitignore").exists());
         assert!(dir.path().join("Dockerfile").exists());
 

--- a/crates/statespace-server/src/content.rs
+++ b/crates/statespace-server/src/content.rs
@@ -114,7 +114,7 @@ mod tests {
 
     fn setup_test_dir() -> TempDir {
         let dir = TempDir::new().unwrap();
-        write(dir.path().join("API.md"), "# Root API").unwrap();
+        write(dir.path().join("llms.txt"), "# Root API").unwrap();
         write(dir.path().join("README.md"), "# Root README").unwrap();
         write(dir.path().join("file.md"), "# File").unwrap();
         write(dir.path().join("no_readme.md"), "# No Readme File").unwrap();

--- a/crates/statespace-server/src/semantics.rs
+++ b/crates/statespace-server/src/semantics.rs
@@ -5,7 +5,7 @@ pub fn markdown_lookup_candidates(path: &str) -> Vec<String> {
     let normalized = path.trim_start_matches('/');
 
     if normalized.is_empty() {
-        return vec!["API.md".to_string()];
+        return vec!["llms.txt".to_string()];
     }
 
     if normalized.ends_with('/') {
@@ -29,7 +29,7 @@ mod tests {
 
     #[test]
     fn markdown_candidates_for_root() {
-        assert_eq!(markdown_lookup_candidates(""), vec!["API.md"]);
+        assert_eq!(markdown_lookup_candidates(""), vec!["llms.txt"]);
     }
 
     #[test]

--- a/crates/statespace-templates/src/AGENTS.md
+++ b/crates/statespace-templates/src/AGENTS.md
@@ -2,7 +2,7 @@
 
 - This file guides coding agents working on a Statespace application.
 - Your job is to help the user create, iterate on, and deploy the app.
-- For the HTTP API contract, read `API.md`.
+- For the HTTP API contract, read `llms.txt`.
 
 ## Set up
 
@@ -102,7 +102,7 @@ Apps aren't limited to Markdown — create scripts and data files as needed alon
 
 ```text
 my-app/
-├── API.md
+├── llms.txt
 ├── README.md
 ├── schema/
 │   ├── users.md

--- a/crates/statespace-templates/src/lib.rs
+++ b/crates/statespace-templates/src/lib.rs
@@ -10,7 +10,7 @@ pub const AGENTS_MD: &str = include_str!("AGENTS.md");
 pub const GITIGNORE: &str = include_str!(".gitignore");
 
 /// App API documentation served at the root of deployed apps.
-pub const API_MD: &str = include_str!("API.md");
+pub const LLMS_TXT: &str = include_str!("llms.txt");
 
 /// A bundled app starter (README.md + optional Dockerfile).
 #[derive(Debug)]

--- a/crates/statespace-templates/src/llms.txt
+++ b/crates/statespace-templates/src/llms.txt
@@ -15,7 +15,7 @@ This Statespace application exposes content and commands over HTTP.
 
 | Path             | Resolves to                                    |
 |------------------|------------------------------------------------|
-| `/`              | `API.md`                                       |
+| `/`              | `llms.txt`                                       |
 | `/page`          | `page`, then `page/README.md`, then `page.md`  |
 | `/dir/`          | `dir/README.md`                                |
 | `/page.md`       | `page.md`                                      |

--- a/docs/pages/develop/filesystem.md
+++ b/docs/pages/develop/filesystem.md
@@ -19,7 +19,7 @@ This creates the following files:
 - **`README.md`** — the main page of your app. Add general tools, instructions, and links here.
 - **`AGENTS.md`** — instructions that teach coding agents how to build and serve on the app.
 - **`CLAUDE.md`** — same content as `AGENTS.md`, picked up automatically by Claude Code.
-- **`API.md`** — HTTP contract instructions for the agent. Served at the root URL (`/`).
+- **`llms.txt`** — HTTP contract instructions for the agent. Served at the root URL (`/`).
 - **`.gitignore`** — pre-configured to exclude secrets and build artifacts.
 
 Agents can read any file with a plain `GET`:

--- a/docs/pages/reference/api.md
+++ b/docs/pages/reference/api.md
@@ -10,7 +10,7 @@ REST API for interacting with Statespace applications.
 
 ## <span class="http-method http-get">GET</span> `/{path}`
 
-Read a file from the app's directory. Requesting `/` returns `API.md`.
+Read a file from the app's directory. Requesting `/` returns `llms.txt`.
 
 <div class="grid" markdown>
 


### PR DESCRIPTION
## Summary

## Changes

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [ ] Docs updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Project Structure**
  * Generated projects now create `llms.txt` instead of `API.md` for HTTP API documentation

* **Documentation**
  * Updated all references to the API documentation filename served at the root path

<!-- end of auto-generated comment: release notes by coderabbit.ai -->