### PR TITLE
feat: restore --visibility flag to statespace deploy

### DIFF
--- a/binaries/statespace-cli/src/args.rs
+++ b/binaries/statespace-cli/src/args.rs
@@ -180,13 +180,13 @@ pub(crate) struct AppDeployArgs {
     #[arg(default_value = ".")]
     pub path: PathBuf,
 
-    /// Application visibility (default: public on free-tier, otherwise private).
-    #[arg(long, value_enum)]
-    pub visibility: Option<Visibility>,
-
     /// Application name. Creates a new app with a random name if omitted.
     #[arg(long, short)]
     pub name: Option<String>,
+
+    /// Application visibility.
+    #[arg(long, value_enum)]
+    pub visibility: Option<Visibility>,
 
     /// Environment variables for deployed app secrets (KEY=VALUE)
     #[arg(long = "env", short = 'e', value_name = "KEY=VALUE")]

--- a/binaries/statespace-cli/src/args.rs
+++ b/binaries/statespace-cli/src/args.rs
@@ -4,6 +4,8 @@ use clap::{
 };
 use std::path::PathBuf;
 
+use crate::gateway::applications::Visibility;
+
 fn init_template_values() -> PossibleValuesParser {
     PossibleValuesParser::new(
         statespace_templates::NAMES
@@ -177,6 +179,10 @@ pub(crate) struct AppDeployArgs {
     /// exclusions can be defined in .gitignore.
     #[arg(default_value = ".")]
     pub path: PathBuf,
+
+    /// Application visibility (default: public on free-tier, otherwise private).
+    #[arg(long, value_enum)]
+    pub visibility: Option<Visibility>,
 
     /// Application name. Creates a new app with a random name if omitted.
     #[arg(long, short)]

--- a/binaries/statespace-cli/src/commands/deploy.rs
+++ b/binaries/statespace-cli/src/commands/deploy.rs
@@ -137,7 +137,7 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
         &files,
         deploy_env.as_ref(),
         visibility_value,
-        &cached,
+        cached.as_ref(),
         &target.name,
     );
 
@@ -145,7 +145,7 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
         &checksums,
         deploy_env.as_ref(),
         visibility_value,
-        &cached,
+        cached.as_ref(),
         &target.name,
     ) {
         eprintln!("No changes detected, skipping deploy.");
@@ -192,19 +192,17 @@ fn build_checksums(
     files: &[ApplicationFile],
     deploy_env: Option<&HashMap<String, String>>,
     visibility_value: Option<&str>,
-    cached: &Option<DeployState>,
+    cached: Option<&DeployState>,
     target_name: &str,
 ) -> Vec<(String, String)> {
     let env_checksum = deploy_env.map(checksum_env_map);
     let persisted_env_checksum = env_checksum.clone().or_else(|| {
         cached
-            .as_ref()
             .filter(|prev| prev.name == target_name)
             .and_then(|prev| prev.checksums.get(ENV_STATE_CHECKSUM_KEY).cloned())
     });
     let persisted_visibility = visibility_value.or_else(|| {
         cached
-            .as_ref()
             .filter(|prev| prev.name == target_name)
             .and_then(|prev| prev.checksums.get(VISIBILITY_STATE_KEY).map(String::as_str))
     });
@@ -226,10 +224,10 @@ fn has_changes(
     checksums: &[(String, String)],
     deploy_env: Option<&HashMap<String, String>>,
     visibility_value: Option<&str>,
-    cached: &Option<DeployState>,
+    cached: Option<&DeployState>,
     target_name: &str,
 ) -> bool {
-    let Some(prev) = cached.as_ref() else {
+    let Some(prev) = cached else {
         return true;
     };
     if prev.name != target_name {

--- a/binaries/statespace-cli/src/commands/deploy.rs
+++ b/binaries/statespace-cli/src/commands/deploy.rs
@@ -129,70 +129,27 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
         eprintln!("No files found in {}", dir.display());
         return Ok(());
     }
-    let env_checksum = deploy_env.as_ref().map(checksum_env_map);
-    let persisted_env_checksum = env_checksum.clone().or_else(|| {
-        cached
-            .as_ref()
-            .filter(|prev| prev.name == target.name)
-            .and_then(|prev| prev.checksums.get(ENV_STATE_CHECKSUM_KEY).cloned())
-    });
-
     let visibility_value = visibility.map(|v| match v {
         Visibility::Public => "public",
         Visibility::Private => "private",
     });
-    let persisted_visibility = visibility_value.or_else(|| {
-        cached
-            .as_ref()
-            .filter(|prev| prev.name == target.name)
-            .and_then(|prev| prev.checksums.get(VISIBILITY_STATE_KEY).map(String::as_str))
-    });
+    let checksums = build_checksums(
+        &files,
+        deploy_env.as_ref(),
+        visibility_value,
+        &cached,
+        &target.name,
+    );
 
-    let mut checksums: Vec<(String, String)> = files
-        .iter()
-        .map(|f| (f.path.clone(), f.checksum.clone()))
-        .collect();
-    if let Some(env_checksum) = &persisted_env_checksum {
-        checksums.push((ENV_STATE_CHECKSUM_KEY.to_string(), env_checksum.clone()));
-    }
-    if let Some(v) = persisted_visibility {
-        checksums.push((VISIBILITY_STATE_KEY.to_string(), v.to_string()));
-    }
-
-    let meta_keys = [ENV_STATE_CHECKSUM_KEY, VISIBILITY_STATE_KEY];
-
-    if let Some(ref prev) = cached {
-        if prev.name == target.name {
-            let filtered_checksums: Vec<(&str, &str)> = checksums
-                .iter()
-                .filter(|(path, _)| !meta_keys.contains(&path.as_str()))
-                .map(|(k, v)| (k.as_str(), v.as_str()))
-                .collect();
-            let prev_map: HashMap<&str, &str> = prev
-                .checksums
-                .iter()
-                .filter(|(path, _)| !meta_keys.contains(&path.as_str()))
-                .map(|(k, v)| (k.as_str(), v.as_str()))
-                .collect();
-            let files_changed = filtered_checksums.len() != prev_map.len()
-                || filtered_checksums
-                    .iter()
-                    .any(|(p, c)| prev_map.get(p) != Some(c));
-            let env_changed = env_checksum.as_ref().is_some_and(|env_checksum| {
-                prev.checksums
-                    .get(ENV_STATE_CHECKSUM_KEY)
-                    .map(String::as_str)
-                    != Some(env_checksum.as_str())
-            });
-            let visibility_changed = visibility_value.is_some_and(|v| {
-                prev.checksums.get(VISIBILITY_STATE_KEY).map(String::as_str) != Some(v)
-            });
-
-            if !files_changed && !env_changed && !visibility_changed {
-                eprintln!("No changes detected, skipping deploy.");
-                return Ok(());
-            }
-        }
+    if !has_changes(
+        &checksums,
+        deploy_env.as_ref(),
+        visibility_value,
+        &cached,
+        &target.name,
+    ) {
+        eprintln!("No changes detected, skipping deploy.");
+        return Ok(());
     }
 
     eprintln!(
@@ -229,6 +186,79 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
     save_state(&dir, &state)?;
 
     Ok(())
+}
+
+fn build_checksums(
+    files: &[ApplicationFile],
+    deploy_env: Option<&HashMap<String, String>>,
+    visibility_value: Option<&str>,
+    cached: &Option<DeployState>,
+    target_name: &str,
+) -> Vec<(String, String)> {
+    let env_checksum = deploy_env.map(checksum_env_map);
+    let persisted_env_checksum = env_checksum.clone().or_else(|| {
+        cached
+            .as_ref()
+            .filter(|prev| prev.name == target_name)
+            .and_then(|prev| prev.checksums.get(ENV_STATE_CHECKSUM_KEY).cloned())
+    });
+    let persisted_visibility = visibility_value.or_else(|| {
+        cached
+            .as_ref()
+            .filter(|prev| prev.name == target_name)
+            .and_then(|prev| prev.checksums.get(VISIBILITY_STATE_KEY).map(String::as_str))
+    });
+
+    let mut checksums: Vec<(String, String)> = files
+        .iter()
+        .map(|f| (f.path.clone(), f.checksum.clone()))
+        .collect();
+    if let Some(c) = &persisted_env_checksum {
+        checksums.push((ENV_STATE_CHECKSUM_KEY.to_string(), c.clone()));
+    }
+    if let Some(v) = persisted_visibility {
+        checksums.push((VISIBILITY_STATE_KEY.to_string(), v.to_string()));
+    }
+    checksums
+}
+
+fn has_changes(
+    checksums: &[(String, String)],
+    deploy_env: Option<&HashMap<String, String>>,
+    visibility_value: Option<&str>,
+    cached: &Option<DeployState>,
+    target_name: &str,
+) -> bool {
+    let Some(prev) = cached.as_ref() else {
+        return true;
+    };
+    if prev.name != target_name {
+        return true;
+    }
+    let meta_keys = [ENV_STATE_CHECKSUM_KEY, VISIBILITY_STATE_KEY];
+    let current: Vec<(&str, &str)> = checksums
+        .iter()
+        .filter(|(k, _)| !meta_keys.contains(&k.as_str()))
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    let prev_map: HashMap<&str, &str> = prev
+        .checksums
+        .iter()
+        .filter(|(k, _)| !meta_keys.contains(&k.as_str()))
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    let files_changed =
+        current.len() != prev_map.len() || current.iter().any(|(p, c)| prev_map.get(p) != Some(c));
+    let env_checksum = deploy_env.map(checksum_env_map);
+    let env_changed = env_checksum.as_ref().is_some_and(|ec| {
+        prev.checksums
+            .get(ENV_STATE_CHECKSUM_KEY)
+            .map(String::as_str)
+            != Some(ec.as_str())
+    });
+    let visibility_changed = visibility_value
+        .is_some_and(|v| prev.checksums.get(VISIBILITY_STATE_KEY).map(String::as_str) != Some(v));
+    files_changed || env_changed || visibility_changed
 }
 
 async fn sync_application_secrets(

--- a/binaries/statespace-cli/src/commands/deploy.rs
+++ b/binaries/statespace-cli/src/commands/deploy.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 const ENV_STATE_CHECKSUM_KEY: &str = "__statespace_env__";
+const VISIBILITY_STATE_KEY: &str = "__statespace_visibility__";
 
 pub(crate) trait DeployGateway {
     fn upsert_application(
@@ -136,6 +137,17 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
             .and_then(|prev| prev.checksums.get(ENV_STATE_CHECKSUM_KEY).cloned())
     });
 
+    let visibility_value = visibility.map(|v| match v {
+        Visibility::Public => "public",
+        Visibility::Private => "private",
+    });
+    let persisted_visibility = visibility_value.or_else(|| {
+        cached
+            .as_ref()
+            .filter(|prev| prev.name == target.name)
+            .and_then(|prev| prev.checksums.get(VISIBILITY_STATE_KEY).map(String::as_str))
+    });
+
     let mut checksums: Vec<(String, String)> = files
         .iter()
         .map(|f| (f.path.clone(), f.checksum.clone()))
@@ -143,18 +155,23 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
     if let Some(env_checksum) = &persisted_env_checksum {
         checksums.push((ENV_STATE_CHECKSUM_KEY.to_string(), env_checksum.clone()));
     }
+    if let Some(v) = persisted_visibility {
+        checksums.push((VISIBILITY_STATE_KEY.to_string(), v.to_string()));
+    }
+
+    let meta_keys = [ENV_STATE_CHECKSUM_KEY, VISIBILITY_STATE_KEY];
 
     if let Some(ref prev) = cached {
         if prev.name == target.name {
             let filtered_checksums: Vec<(&str, &str)> = checksums
                 .iter()
-                .filter(|(path, _)| path.as_str() != ENV_STATE_CHECKSUM_KEY)
+                .filter(|(path, _)| !meta_keys.contains(&path.as_str()))
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect();
             let prev_map: HashMap<&str, &str> = prev
                 .checksums
                 .iter()
-                .filter(|(path, _)| path.as_str() != ENV_STATE_CHECKSUM_KEY)
+                .filter(|(path, _)| !meta_keys.contains(&path.as_str()))
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect();
             let files_changed = filtered_checksums.len() != prev_map.len()
@@ -167,8 +184,14 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
                     .map(String::as_str)
                     != Some(env_checksum.as_str())
             });
+            let visibility_changed = visibility_value.is_some_and(|v| {
+                prev.checksums
+                    .get(VISIBILITY_STATE_KEY)
+                    .map(String::as_str)
+                    != Some(v)
+            });
 
-            if !files_changed && !env_changed {
+            if !files_changed && !env_changed && !visibility_changed {
                 eprintln!("No changes detected, skipping deploy.");
                 return Ok(());
             }

--- a/binaries/statespace-cli/src/commands/deploy.rs
+++ b/binaries/statespace-cli/src/commands/deploy.rs
@@ -185,10 +185,7 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
                     != Some(env_checksum.as_str())
             });
             let visibility_changed = visibility_value.is_some_and(|v| {
-                prev.checksums
-                    .get(VISIBILITY_STATE_KEY)
-                    .map(String::as_str)
-                    != Some(v)
+                prev.checksums.get(VISIBILITY_STATE_KEY).map(String::as_str) != Some(v)
             });
 
             if !files_changed && !env_changed && !visibility_changed {
@@ -205,7 +202,9 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
         target.name
     );
 
-    let upsert_result = gateway.upsert_application(&target.name, files, visibility).await?;
+    let upsert_result = gateway
+        .upsert_application(&target.name, files, visibility)
+        .await?;
     let result = DeployOutcome::from_upsert(upsert_result);
 
     let sync = match deploy_env.as_ref() {

--- a/binaries/statespace-cli/src/commands/deploy.rs
+++ b/binaries/statespace-cli/src/commands/deploy.rs
@@ -2,7 +2,7 @@ use crate::args::AppDeployArgs;
 use crate::commands::env::resolve_env_overrides;
 use crate::error::{Error, Result};
 use crate::gateway::GatewayClient;
-use crate::gateway::applications::{ApplicationFile, UpsertResult};
+use crate::gateway::applications::{ApplicationFile, UpsertResult, Visibility};
 use crate::names::generate_name;
 use crate::state::{DeployState, load_state, save_state};
 use sha2::{Digest, Sha256};
@@ -15,6 +15,7 @@ pub(crate) trait DeployGateway {
         &self,
         name: &str,
         files: Vec<ApplicationFile>,
+        visibility: Option<Visibility>,
     ) -> impl std::future::Future<Output = Result<UpsertResult>> + Send;
 
     fn list_secret_keys(
@@ -41,8 +42,9 @@ impl DeployGateway for GatewayClient {
         &self,
         name: &str,
         files: Vec<ApplicationFile>,
+        visibility: Option<Visibility>,
     ) -> Result<UpsertResult> {
-        self.upsert_application(name, files).await
+        self.upsert_application(name, files, visibility).await
     }
 
     async fn list_secret_keys(&self, application_id: &str) -> Result<Vec<String>> {
@@ -94,6 +96,7 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
     let AppDeployArgs {
         path,
         name,
+        visibility,
         env_vars,
         env_file,
         cloud: _,
@@ -179,7 +182,7 @@ pub(crate) async fn run_deploy(args: AppDeployArgs, gateway: impl DeployGateway)
         target.name
     );
 
-    let upsert_result = gateway.upsert_application(&target.name, files).await?;
+    let upsert_result = gateway.upsert_application(&target.name, files, visibility).await?;
     let result = DeployOutcome::from_upsert(upsert_result);
 
     let sync = match deploy_env.as_ref() {
@@ -312,6 +315,7 @@ mod tests {
             &self,
             name: &str,
             files: Vec<ApplicationFile>,
+            _visibility: Option<Visibility>,
         ) -> Result<UpsertResult> {
             self.upsert_calls
                 .lock()
@@ -356,6 +360,7 @@ mod tests {
         AppDeployArgs {
             path,
             name: name.map(ToOwned::to_owned),
+            visibility: None,
             env_vars: Vec::new(),
             env_file: None,
             cloud: crate::args::CloudArgs {

--- a/binaries/statespace-cli/src/gateway/applications.rs
+++ b/binaries/statespace-cli/src/gateway/applications.rs
@@ -1,3 +1,4 @@
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
@@ -18,6 +19,13 @@ pub(crate) struct UpsertResult {
     pub name: String,
     pub url: Option<String>,
     pub auth_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Visibility {
+    Public,
+    Private,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]

--- a/binaries/statespace-cli/src/gateway/client.rs
+++ b/binaries/statespace-cli/src/gateway/client.rs
@@ -121,10 +121,13 @@ impl GatewayClient {
         &self,
         name: &str,
         files: Vec<ApplicationFile>,
+        visibility: Option<crate::gateway::applications::Visibility>,
     ) -> Result<UpsertResult> {
         #[derive(Serialize)]
         struct Payload {
             files: Vec<ApplicationFile>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            visibility: Option<crate::gateway::applications::Visibility>,
         }
 
         let url = format!(
@@ -134,7 +137,7 @@ impl GatewayClient {
         );
         let resp = self
             .with_headers(self.http.put(&url))
-            .json(&Payload { files })
+            .json(&Payload { files, visibility })
             .send()
             .await?;
 


### PR DESCRIPTION
## Summary

## Changes

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

## Checklist

- [ ] Docs updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--visibility` CLI option to the deploy command to mark deployments as public or private.

* **Bug Fixes / Behavior Changes**
  * Deploy change detection now considers visibility, so changing visibility will trigger an update rather than being treated as "no changes detected."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->